### PR TITLE
Fixed doubling up of SwiftUI Image namespace.

### DIFF
--- a/Example/FaviconFinder/ContentView.swift
+++ b/Example/FaviconFinder/ContentView.swift
@@ -45,8 +45,7 @@ struct ContentView: View {
 
 @available(OSX 10.15, *)
 struct ContentView_Previews: PreviewProvider {
-    static var previews: some View
-    {
+    static var previews: some View {
         ContentView()
     }
 }

--- a/Example/FaviconFinder_iOS_Example/ViewController.swift
+++ b/Example/FaviconFinder_iOS_Example/ViewController.swift
@@ -32,7 +32,7 @@ class ViewController: UIViewController {
             switch result {
             case .success(let favicon):
                 print("URL of Favicon: \(favicon.url)")
-                self.imageView.image = image
+                self.imageView.image = favicon.image
 
             case .failure(let error):
                 print("Error: \(error)")

--- a/FaviconFinder.podspec
+++ b/FaviconFinder.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
                           DESC
 
   s.author             = { "William Lumley" => "will@lumley.io" }
-  s.social_media_url   = "http://twitter.com/wlumley95"
+  s.social_media_url   = "https://twitter.com/wlumley95"
 
   s.ios.deployment_target = "10.0"
   s.osx.deployment_target = "10.10"

--- a/Sources/FaviconFinder/Classes/FaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinder.swift
@@ -7,15 +7,15 @@
 //
 #if targetEnvironment(macCatalyst)
 import UIKit
-public typealias Image = UIImage
+public typealias FaviconImage = UIImage
 
 #elseif canImport(AppKit)
 import AppKit
-public typealias Image = NSImage
+public typealias FaviconImage = NSImage
 
 #elseif canImport(UIKit)
 import UIKit
-public typealias Image = UIImage
+public typealias FaviconImage = UIImage
 
 #endif
 
@@ -27,7 +27,7 @@ import SwiftSoup
 public class FaviconFinder: NSObject {
 
     public struct Favicon {
-        public let image: Image
+        public let image: FaviconImage
         public let url: URL
     }
 
@@ -176,7 +176,7 @@ public class FaviconFinder: NSObject {
                 return
             }
             
-            guard let image = Image(data: data) else {
+            guard let image = FaviconImage(data: data) else {
                 if self.isLogEnabled {
                     print("Could NOT create favicon from data.")
                 }


### PR DESCRIPTION
Replaced `Image` with `FaviconImage`