### PR TITLE
Make searchForFaviconInHTML public

### DIFF
--- a/Sources/FaviconFinder/Classes/FaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinder.swift
@@ -103,7 +103,7 @@ public class FaviconFinder: NSObject {
     /**
      Searches for a link to the favicon within the HTML header
      */
-    private func searchForFaviconInHTML(onDownload: @escaping ((_ result: Result<Favicon, FaviconError>) -> Void)) {
+    public func searchForFaviconInHTML(onDownload: @escaping ((_ result: Result<Favicon, FaviconError>) -> Void)) {
         //Download the web page at our URL
         URLSession.shared.dataTask(with: self.url, completionHandler: {(data, response, error) in
             


### PR DESCRIPTION
Hi 👋 I like the lib, but for _my_ use case the regular favicon is not enough, I want the high-res one, if there is one. For that, I can skip the call to /favicon.ico and scan through the HTML directly.
Therefore, I need `searchForFaviconInHTML` to be public.

Would you consider this something that should be upstreamed? If so, this PR is for you 😊 