### PR TITLE
Fix mostPreferrableIcon

### DIFF
--- a/Sources/FaviconFinder/Classes/FaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinder.swift
@@ -307,29 +307,9 @@ private extension FaviconFinder
      - returns: The most preferred image link from our aray of icons
      */
     func mostPreferrableIcon(icons: [(rel: String, href: String)]) -> (rel: String, href: String)? {
-        for icon in icons {
-            let rel  = icon.rel
-            
-            switch rel {
-            case FaviconRelType.appleTouchIcon.rawValue:
-                return icon
-
-            case FaviconRelType.appleTouchIconPrecomposed.rawValue:
-                return icon
-
-            case FaviconRelType.shortcutIcon.rawValue:
-                return icon
-                
-            case FaviconRelType.icon.rawValue:
-                return icon
-                
-            default:
-                if isLogEnabled {
-                    print("Not using link rel: \(rel)")
-                }
-            }
-        }
-        
-        return nil
+        return icons.first(where: { rel, _ in rel == FaviconRelType.appleTouchIcon.rawValue }) ??
+            icons.first(where: { rel, _ in rel == FaviconRelType.appleTouchIconPrecomposed.rawValue }) ??
+            icons.first(where: { rel, _ in rel == FaviconRelType.shortcutIcon.rawValue }) ??
+            icons.first(where: { rel, _ in rel == FaviconRelType.icon.rawValue })
     }
 }


### PR DESCRIPTION
The current implementation of `mostPreferrableIcon` will always return the **first** icon that was defined in the html-head that matches _any_ of the `FaviconRelType` cases.

Example:

* icons = [Foo1(icon), Foo2(appleTouchIcon)]
* `for` evaluates the first element
* that matches `icon`
* the function returns
* `Foo2` is never evaluated

My understanding of the _most preferable icon_ would be the _highest resolution, though.

The proposed function first looks for the `appleTouchIcon`, then `appleTouchIconPrecomposed`, then `shortcutIcon` and finally `icon`.

If this was the original intend, feel free to merge this 😊 