### PR TITLE
Use URL(string, relativeTo) to concat relative URLs

### DIFF
--- a/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
@@ -159,10 +159,7 @@ private extension HTMLFaviconFinder {
         
         //If we don't have a http or https prepended to our href, prepend our base domain
         if !Regex.testForHttpsOrHttp(input: href) {
-            let protocolFormat = "\(self.url.scheme ?? "https")://"
-            let domain = self.url.host ?? self.url.absoluteString
-
-            guard let url = URL(string: "\(protocolFormat)\(domain)")?.appendingPathComponent(href) else {
+            guard let url = URL(string: href, relativeTo: self.url) else {
                 return nil
             }
 


### PR DESCRIPTION
This should properly resolve relative URLs like `<link rel="icon" href="../../assets/icons/favicon.ico">` by using the `relativeTo` initialiser: https://developer.apple.com/documentation/foundation/nsurl/1417949-init

I _think_ the `protocolFormat` and `domain` aren't required anymore, because they are now taken from `self.url` directly.

Fixes #35 