### PR TITLE
Follow <base> tag to resolve hrefs

### DIFF
--- a/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
@@ -159,10 +159,16 @@ private extension HTMLFaviconFinder {
         
         //If we don't have a http or https prepended to our href, prepend our base domain
         if !Regex.testForHttpsOrHttp(input: href) {
-            let protocolFormat = "\(self.url.scheme ?? "https")://"
-            let domain = self.url.host ?? self.url.absoluteString
+            let baseRef = { () -> URL in
+                if let baseRef = try? html.head()?.getElementsByTag("base").attr("href"),
+                   let baseRefUrl = URL(string: baseRef) {
+                    return baseRefUrl
+                } else {
+                    return self.url
+                }
+            }
 
-            guard let url = URL(string: "\(protocolFormat)\(domain)")?.appendingPathComponent(href) else {
+            guard let url = URL(string: href, relativeTo: baseRef()) else {
                 return nil
             }
 

--- a/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
@@ -161,7 +161,7 @@ private extension HTMLFaviconFinder {
         if !Regex.testForHttpsOrHttp(input: href) {
             let baseRef = { () -> URL in
                 if let baseRef = try? html.head()?.getElementsByTag("base").attr("href"),
-                   let baseRefUrl = URL(string: baseRef) {
+                   let baseRefUrl = URL(string: baseRef, relativeTo: self.url) {
                     return baseRefUrl
                 } else {
                     return self.url


### PR DESCRIPTION
Follow-up to #37 

Some people just want to push html to the limit. https://www.block-house.de/restaurants/ for example defines

```
<base href="https://www.block-house.de/">
```

and then only uses relative links _to that base_ instead of the current directory! So

```
<link rel="icon" type="image/x-icon" href="fileadmin/block-house/icons/favicon.ico">
```

is not https://www.block-house.de/restaurants/fileadmin/block-house/icons/favicon.ico but https://www.block-house.de/fileadmin/block-house/icons/favicon.ico.

This change add support for reading the `<base>` tag for the `HTMLFaviconFinder`.