### PR TITLE
ICOFaviconFinder: Add support for URLs with path

### DIFF
--- a/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
@@ -24,22 +24,27 @@ class ICOFaviconFinder: FaviconFinderProtocol {
         // If there's not, try the root instead.
         // Then, remove the RootICO finder and type.
 
-        let url = self.url.appendingPathComponent(self.preferredType)
-
+        let baseUrl = URL(string: "/", relativeTo: self.url)
+        guard let faviconUrl = URL(string: self.preferredType, relativeTo: baseUrl) else {
+            onFind(.failure(.failedToFindFavicon))
+            return
+        }
+        
         // Switch to the background thread, as we'll be doing some networking
         DispatchQueue.global().async {
 
             // We have the URL, let's see if there's any valid image data here
-            if let data = try? Data(contentsOf: url), let _ = FaviconImage(data: data) {
+            if let data = try? Data(contentsOf: faviconUrl), let _ = FaviconImage(data: data) {
                 // We found valid image data, woohoo!
-                let faviconURL = FaviconURL(url: url, type: .ico)
+                let faviconURL = FaviconURL(url: faviconUrl, type: .ico)
                 onFind(.success(faviconURL))
             } else {
                 // We couldn't find any image, but let's try the root domain (just in case it's hiding there)
                 // ie. If we couldn't find the image at "subdomain.google.com/favicon.ico", let's try "google.com/favicon.ico"
 
                 // Create the URL, removing subdomains
-                guard let rootURL = self.url.urlWithoutSubdomains?.appendingPathComponent(self.preferredType) else {
+                guard let base = self.url.urlWithoutSubdomains?.deletingPathExtension(),
+                      let rootURL = URL(string: self.preferredType, relativeTo: base) else {
                     // We couldn't find the image at the root domain, so let's give the user a failure.
                     onFind(.failure(.failedToFindFavicon))
                     return
@@ -48,7 +53,7 @@ class ICOFaviconFinder: FaviconFinderProtocol {
                 // We created a URL without the subdomains, let's check if there's a valid image there
                 if let data = try? Data(contentsOf: rootURL), let _ = FaviconImage(data: data) {
                     // We found valid image data, woohoo!
-                    let faviconURL = FaviconURL(url: url, type: .ico)
+                    let faviconURL = FaviconURL(url: rootURL, type: .ico)
                     onFind(.success(faviconURL))
                 } else {
                     // Well we couldn't find any valid image data at the provided URL, nor the root domain, game over.


### PR DESCRIPTION
Basically what #37 does, but for the `ICOFaviconFinder`. It's a little more complicated, because there's no ~good~ better way to get "scheme + host" from a URL than `URL(string: "/", relativeTo: self.url)`.