### PR TITLE
4.0.4, Exclusive Async and Await support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/FaviconFinder/ContentView.swift
+++ b/Example/FaviconFinder/ContentView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import Combine
 import FaviconFinder
 
-@available(OSX 10.15, *)
 struct ContentView: View {
     @State var urlStr = "https://apple.com/au"
     @ObservedObject var imageLoader = ImageLoader()
@@ -43,31 +42,28 @@ struct ContentView: View {
     }
 }
 
-@available(OSX 10.15, *)
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
     }
 }
 
-@available(OSX 10.15, *)
 final class ImageLoader: ObservableObject {
     @Published private(set) var image: NSImage? = nil
-
+    
     private var url: URL? = nil
-
+    
     func load(url: URL) {
-        FaviconFinder(url: url, preferredType: .html, preferences: [
-            FaviconDownloadType.html: FaviconType.appleTouchIcon.rawValue,
-            FaviconDownloadType.ico: "favicon.ico"
-        ]).downloadFavicon { result in
-            switch result {
-            case .success(let favicon):
-                print("URL of Favicon: \(favicon.url)")
+        Task {
+            do {
+                let favicon = try await FaviconFinder(url: url, preferredType: .html, preferences: [
+                    FaviconDownloadType.html: FaviconType.appleTouchIcon.rawValue,
+                    FaviconDownloadType.ico: "favicon.ico"
+                ]).downloadFavicon()
+                
                 self.image = favicon.image
-
-            case .failure(let error):
-                NSAlert(error: error).runModal()
+            } catch {
+                print(error)
             }
         }
     }

--- a/Example/FaviconFinder/ExampleViewController.swift
+++ b/Example/FaviconFinder/ExampleViewController.swift
@@ -29,19 +29,18 @@ class ExampleViewController: NSViewController
             return
         }
         
-        FaviconFinder(url: url, preferredType: .html, preferences: [
-            .html: FaviconType.appleTouchIcon.rawValue,
-            .ico: "favicon.ico"
-        ]).downloadFavicon { result in
-            switch result {
-            case .success(let favicon):
-                print("URL of Favicon: \(favicon.url)")
+        Task {
+            do {
+                let favicon = try await FaviconFinder(url: url, preferredType: .html, preferences: [
+                    FaviconDownloadType.html: FaviconType.appleTouchIcon.rawValue,
+                    FaviconDownloadType.ico: "favicon.ico"
+                ]).downloadFavicon()
+                
                 DispatchQueue.main.async {
                     self.imageView.image = favicon.image
                 }
-
-            case .failure(let error):
-                print("Error: \(error)")
+            } catch {
+                print(error)
             }
         }
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftSoup",
+        "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
+        "state": {
+          "branch": null,
+          "revision": "774dc9c7213085db8aa59595e27c1cd22e428904",
+          "version": "2.3.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "FaviconFinder",
+    platforms: [.iOS(.v15), .macOS(.v12), .watchOS(.v8), .tvOS(.v15)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Sources/FaviconFinder/Classes/FaviconFinderProtocol.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinderProtocol.swift
@@ -9,27 +9,12 @@ import Foundation
 
 protocol FaviconFinderProtocol {
 
-    /// The URL of the website we're querying the Favicon for
     var url: URL { get set }
-
-    /// Whether or not we this Finder will log information to the console
     var logEnabled: Bool { get set }
-
-    /// The preferred type of Favicon. This is dependant on type.
-    /// For example, `ICOFaviconFinder` the `preferredType` is a filename, for `WebApplicationManifestFaviconFinder` the
-    /// `preferredType` is the desired key in the JSON file, etc.
     var preferredType: String { get set }
 
-    /// A string representation of the class name. Used for logging purposes.
-    var description: String { get }
+    init(url: URL, preferredType: String?, logEnabled: Bool)
 
-    /// Indicates if we should check for a meta-refresh-redirect tag in the HTML header
-    var checkForMetaRefreshRedirect: Bool { get }
-
-    /// An instance of the object we direct logging through.
-    var logger: Logger? { get }
-
-    init(url: URL, preferredType: String?, checkForMetaRefreshRedirect: Bool, logEnabled: Bool)
-    func search(onFind: @escaping ((_ result: Result<FaviconURL, FaviconError>) -> Void))
+    func search() async throws -> FaviconURL
 
 }

--- a/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
@@ -9,6 +9,7 @@ import Foundation
 
 #if canImport(SwiftSoup)
 import SwiftSoup
+
 #endif
 
 class HTMLFaviconFinder: FaviconFinderProtocol {
@@ -18,72 +19,37 @@ class HTMLFaviconFinder: FaviconFinderProtocol {
     struct HTMLFaviconReference {
         let rel: String
         let href: String
-        let sizes: String?
     }
 
     // MARK: - Properties
 
     var url: URL
     var preferredType: String
-    var checkForMetaRefreshRedirect: Bool
-
     var logEnabled: Bool
-    var description: String
-    var logger: Logger?
 
     /// When parsing through HTML, these are the type of images we'll look for in the HTML header
-    private let acceptableIconTypes = FaviconType.allTypes
+    private var acceptableIconTypes = FaviconType.allTypes
 
-    // MARK: - FaviconFinder
+    /// The preferred type of favicon we're after
+    //var preferredType: String? = FaviconType.appleTouchIcon.rawValue
 
-    required init(url: URL, preferredType: String?, checkForMetaRefreshRedirect: Bool, logEnabled: Bool) {
+    required init(url: URL, preferredType: String?, logEnabled: Bool) {
         self.url = url
-        self.preferredType = preferredType ?? FaviconType.appleTouchIcon.rawValue // Default to `appleTouchIcon` type if user does not present us with one
-        self.checkForMetaRefreshRedirect = checkForMetaRefreshRedirect
-
+        self.preferredType = preferredType ?? FaviconType.appleTouchIcon.rawValue //Default to `appleTouchIcon` type if user does not present us with one
         self.logEnabled = logEnabled
-        self.description = NSStringFromClass(HTMLFaviconFinder.self)
-        self.logger = Logger(faviconFinder: self)
     }
 
-    func search(onFind: @escaping ((Result<FaviconURL, FaviconError>) -> Void)) {
+    func search() async throws -> FaviconURL {
 
-        // Download the web page at our URL
-        FaviconURLRequest.dataTask(
-            with: self.url,
-            checkForMetaRefreshRedirect: self.checkForMetaRefreshRedirect
-        ) { data, response, error in
-
-            // Make sure our data exists
-            guard let data = data else {
-                self.logger?.print("Could NOT get favicon from url: \(self.url), Data was nil.")
-                onFind(.failure(.emptyData))
-                return
-            }
-
-            // Make sure we can parse the response into a string
-            guard let html = String(data: data, encoding: .utf8) else {
-                self.logger?.print("Could NOT get favicon from url: \(self.url), could not parse HTML.")
-                onFind(.failure(.failedToParseHTML))
-                return
-            }
-
-            // Make sure we can find a favicon in our retrieved string (at this point we're assuming it's valid HTML)
-            guard let faviconURL = self.faviconURL(from: html) else {
-                self.logger?.print("Could NOT get favicon from url: \(self.url), failed to parse favicon from HTML.")
-                onFind(.failure(.failedToDownloadFavicon))
-                return
-            }
-
-            // We found our favicon, let's download it
-            Logger.print(self.logEnabled, "Extracted favicon: \(faviconURL.url.absoluteString)")
-            onFind(.success(faviconURL))
-            
-        }
+        //Download the web page at our URL
+        let data = try await URLSession.shared.data(from: self.url).0
+        
+        guard let html = String(data: data, encoding: .utf8) else { throw FaviconError.failedToParseHTML }
+        guard let faviconURL = self.faviconURL(from: html) else { throw FaviconError.failedToDownloadFavicon }
+        return faviconURL
     }
+
 }
-
-// MARK: - Private Functions
 
 private extension HTMLFaviconFinder {
 
@@ -98,17 +64,23 @@ private extension HTMLFaviconFinder {
             htmlOpt = try SwiftSoup.parse(htmlStr)
         }
         catch let error {
-            self.logger?.print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
+            if logEnabled {
+                print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
+            }
             return nil
         }
         
         guard let html = htmlOpt else {
-            self.logger?.print("Could NOT parse HTML from string: \(htmlStr)")
+            if logEnabled {
+                print("Could NOT parse HTML from string: \(htmlStr)")
+            }
             return nil
         }
         
         guard let head = html.head() else {
-            self.logger?.print("Could NOT parse HTML head from string: \(htmlStr)")
+            if logEnabled {
+                print("Could NOT parse HTML head from string: \(htmlStr)")
+            }
             return nil
         }
 
@@ -120,30 +92,33 @@ private extension HTMLFaviconFinder {
             allLinks = try head.select("link")
         }
         catch let error {
-            self.logger?.print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
+            if logEnabled {
+                print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
+            }
             return nil
         }
         
-        // Iterate over every 'link' tag that's in the head document, and collect them
+        //Iterate over every 'link' tag that's in the head document, and collect them
         for element in allLinks {
             do {
                 let rel = try element.attr("rel")
                 let href = try element.attr("href")
-                let sizes = try element.attr("sizes")
                 
                 //If this is an icon that we deem might be a favicon, add it to our array
                 if FaviconType.contains(relTypes: self.acceptableIconTypes, rawRelType: rel) {
-                    let possibleIcon = HTMLFaviconReference(rel: rel, href: href, sizes: sizes)
+                    let possibleIcon = HTMLFaviconReference(rel: rel, href: href)
                     possibleIcons.append(possibleIcon)
                 }
             }
             catch let error {
-                self.logger?.print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
+                if logEnabled {
+                    print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
+                }
                 continue
             }
         }
 
-        // Extract the most preferrable icon, and return it's href as a URL object
+        //Extract the most preferrable icon, and return it's href as a URL object
         guard let mostPreferrableIcon = self.mostPreferrableIcon(icons: possibleIcons) else {
             return nil
         }
@@ -204,22 +179,13 @@ private extension HTMLFaviconFinder {
             return (icon: icon, type: FaviconType(rawValue: icon.rel)!)
         }
 
-        // Check for icon type
-        let iconTypeIcons = icons.enumerated().filter({FaviconType(rawValue: $1.rel) == .icon})
-        
-        // Sort in sizes (like "64x64")
-        let sizes = iconTypeIcons.map({ index, icon -> (index: Int, size: Int) in
-            let iconSize = Int(icon.sizes?.components(separatedBy: "x").first ?? "") ?? 0
-            return (index: index, size: iconSize)
-        }).sorted(by: {$0.size > $1.size})
-
-        if let firstSize = sizes.first {
-            let icon = icons[firstSize.index]
+        // Check for shortcutIcon type
+        else if let icon = icons.first(where: { FaviconType(rawValue: $0.rel) == .shortcutIcon }) {
             return (icon: icon, type: FaviconType(rawValue: icon.rel)!)
         }
 
-        // Check for shortcutIcon type last since it's often a low quality .ico file
-        if let icon = icons.first(where: { FaviconType(rawValue: $0.rel) == .shortcutIcon }) {
+        // Check for icon type
+        else if let icon = icons.first(where: { FaviconType(rawValue: $0.rel) == .icon }) {
             return (icon: icon, type: FaviconType(rawValue: icon.rel)!)
         }
 

--- a/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
@@ -7,70 +7,43 @@
 
 import Foundation
 
-class ICOFaviconFinder: FaviconFinderProtocol {    
-
-    // MARK: - Properties
+class ICOFaviconFinder: FaviconFinderProtocol {
 
     var url: URL
     var preferredType: String
-    var checkForMetaRefreshRedirect: Bool
-
     var logEnabled: Bool
-    var description: String
-    var logger: Logger?
 
-    // MARK: - FaviconFinder
-
-    required init(url: URL, preferredType: String?, checkForMetaRefreshRedirect: Bool, logEnabled: Bool) {
+    required init(url: URL, preferredType: String?, logEnabled: Bool) {
         self.url = url
-        self.preferredType = preferredType ?? "favicon.ico" // Default to the filename of "favicon.ico" if user does not present us with one
-        self.checkForMetaRefreshRedirect = checkForMetaRefreshRedirect
-
+        self.preferredType = preferredType ?? "favicon.ico" //Default to the filename of "favicon.ico" if user does not present us with one
         self.logEnabled = logEnabled
-        self.description = NSStringFromClass(Self.self)
-        self.logger = Logger(faviconFinder: self)
     }
 
-    func search(onFind: @escaping ((Result<FaviconURL, FaviconError>) -> Void)) {
+    func search() async throws -> FaviconURL {
         // TODO: Check that there's an actual image at the path.
         // If there's not, try the root instead.
         // Then, remove the RootICO finder and type.
 
         let baseUrl = URL(string: "/", relativeTo: self.url)
         guard let faviconUrl = URL(string: self.preferredType, relativeTo: baseUrl) else {
-            onFind(.failure(.failedToFindFavicon))
-            return
+            throw FaviconError.failedToFindFavicon
         }
-
-        // Switch to the background thread, as we'll be doing some networking
-        DispatchQueue.global().async {
-
-            // We have the URL, let's see if there's any valid image data here
-            if let data = try? Data(contentsOf: faviconUrl), let _ = FaviconImage(data: data) {
-                // We found valid image data, woohoo!
-                let faviconURL = FaviconURL(url: faviconUrl, type: .ico)
-                onFind(.success(faviconURL))
+        
+        let data = try await URLSession.shared.data(from: faviconUrl).0
+        if FaviconImage(data: data) != nil {
+            return FaviconURL(url: faviconUrl, type: .ico)
+        } else {
+            guard let base = self.url.urlWithoutSubdomains?.deletingPathExtension(),
+                  let rootURL = URL(string: self.preferredType, relativeTo: base) else {
+                      // We couldn't find the image at the root domain, so let's give the user a failure.
+                      throw FaviconError.failedToFindFavicon
+                  }
+            let data = try await URLSession.shared.data(from: rootURL).0
+            
+            if FaviconImage(data: data) != nil {
+                return FaviconURL(url: rootURL, type: .ico)
             } else {
-                // We couldn't find any image, but let's try the root domain (just in case it's hiding there)
-                // ie. If we couldn't find the image at "subdomain.google.com/favicon.ico", let's try "google.com/favicon.ico"
-
-                // Create the URL, removing subdomains
-                guard let base = self.url.urlWithoutSubdomains?.deletingPathExtension(),
-                      let rootURL = URL(string: self.preferredType, relativeTo: base) else {
-                    // We couldn't find the image at the root domain, so let's give the user a failure.
-                    onFind(.failure(.failedToFindFavicon))
-                    return
-                }
-
-                // We created a URL without the subdomains, let's check if there's a valid image there
-                if let data = try? Data(contentsOf: rootURL), let _ = FaviconImage(data: data) {
-                    // We found valid image data, woohoo!
-                    let faviconURL = FaviconURL(url: rootURL, type: .ico)
-                    onFind(.success(faviconURL))
-                } else {
-                    // Well we couldn't find any valid image data at the provided URL, nor the root domain, game over.
-                    onFind(.failure(.failedToFindFavicon))
-                }
+                throw FaviconError.failedToFindFavicon
             }
         }
     }


### PR DESCRIPTION
I replaced all the functions to use async. This greatly improves performance especially in lists but as of right now requires iOS 15 and macOS 12 until Apple adds backwards deployment. Users can pull from 3.2.0 if they don't want iOS 15 exclusivity.

If you want to still support the old methods, you will need to add them back on this fork but for my use case, this works perfect.