### PR TITLE
Add data property in Favicon struct

### DIFF
--- a/Sources/FaviconFinder/Classes/FaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinder.swift
@@ -149,7 +149,7 @@ private extension FaviconFinder {
 
             let downloadType = FaviconDownloadType(type: type)
 
-            let favicon = Favicon(image: image, url: url, type: type, downloadType: downloadType)
+            let favicon = Favicon(image: image, data: data, url: url, type: type, downloadType: downloadType)
             onDownload(.success(favicon))
             
         }).resume()

--- a/Sources/FaviconFinder/Classes/Types/Favicon.swift
+++ b/Sources/FaviconFinder/Classes/Types/Favicon.swift
@@ -11,6 +11,8 @@ public struct Favicon {
 
     /// The actual image
     public let image: FaviconImage
+  
+    public let data: Data
 
     /// The url of the .ico or HTML page, of where the favicon was found
     public let url: URL


### PR DESCRIPTION
NSImage or UIImage doesn't really offer a way to let us retrieve the original data.

With data property we can persist favicon in file system to avoid constant fetching.