### PR TITLE
Meta Refresh Redirect

### DIFF
--- a/Example/FaviconFinder/ExampleViewController.swift
+++ b/Example/FaviconFinder/ExampleViewController.swift
@@ -23,7 +23,7 @@ class ExampleViewController: NSViewController
     @IBAction func downloadButtonTapped(_ sender: Any)
     {
         let urlStr = self.textField.stringValue
-        
+
         guard let url = URL(string: urlStr) else {
             print("Not a valid URL: \(urlStr)")
             return

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -136,6 +136,10 @@
 		BA2FBE79F97E75615F3497E62BA37FE1 /* DataNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3449BB90781627254A26AE3462B2641 /* DataNode.swift */; };
 		BACBDDB85DCED8CB0EF71E0A8DB00A1E /* Pattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347FD70CAA199954EDF07FDB9DAD6470 /* Pattern.swift */; };
 		BD756583E3A0486F2651C5E6256D5CC0 /* TreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C095A47F4007A71D72667867D375BE /* TreeBuilder.swift */; };
+		BE46622427D2DD3C002D02F9 /* FaviconURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE46622327D2DD3C002D02F9 /* FaviconURLRequest.swift */; };
+		BE46622527D2DD3C002D02F9 /* FaviconURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE46622327D2DD3C002D02F9 /* FaviconURLRequest.swift */; };
+		BEC4954727D1C36A002E82E3 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC4954627D1C36A002E82E3 /* Logger.swift */; };
+		BEC4954827D1C36A002E82E3 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC4954627D1C36A002E82E3 /* Logger.swift */; };
 		C01AFA2C713342F11B9310E875AB11A1 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A54C97DEB1A3977AC3A62AFF00971BF /* Cocoa.framework */; };
 		C6212711C027923BFEE0EDDEBBF56E3A /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555EEAE004EA043704A0CEDAB82F187C /* Document.swift */; };
 		C683F63C87B5F4AE6D380920DCCA5758 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A54C97DEB1A3977AC3A62AFF00971BF /* Cocoa.framework */; };
@@ -243,7 +247,7 @@
 		1544DC46B9F50A6DF32483B8755AC4A7 /* DocumentType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentType.swift; path = Sources/DocumentType.swift; sourceTree = "<group>"; };
 		179A888C4C7AB464643A7CE7357EAC15 /* OrderedSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrderedSet.swift; path = Sources/OrderedSet.swift; sourceTree = "<group>"; };
 		1B9B924DDF35ED5BC47A63B8DE3C9BB1 /* Pods-FaviconFinder_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FaviconFinder_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		1BA807BD869B9DC43511DFA0EEA60E3F /* FaviconFinder.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = FaviconFinder.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		1BA807BD869B9DC43511DFA0EEA60E3F /* FaviconFinder.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = FaviconFinder.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		1C974F3AD02EE46AB341F415C8B643F2 /* StructuralEvaluator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StructuralEvaluator.swift; path = Sources/StructuralEvaluator.swift; sourceTree = "<group>"; };
 		23174E66D21709BBE2A289D0B6BB4519 /* StringBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringBuilder.swift; path = Sources/StringBuilder.swift; sourceTree = "<group>"; };
 		29CAE34DEA444CE23E9E30F90C655A8A /* Pods-FaviconFinder_iOS_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FaviconFinder_iOS_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -301,7 +305,7 @@
 		7E0947EC7B3987ADD5B0A686D3C1E383 /* SwiftSoup-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "SwiftSoup-iOS.modulemap"; sourceTree = "<group>"; };
 		7FFCBFA2B10F943E91AF7B1DFB6EC549 /* Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.swift; path = Sources/Node.swift; sourceTree = "<group>"; };
 		8031035D9C171767CA3D88684089F73F /* Pods-FaviconFinder_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-FaviconFinder_Example.release.xcconfig"; sourceTree = "<group>"; };
-		80F75A59FF01CC64B720E9DF705711FE /* LICENSE.txt */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE.txt; sourceTree = "<group>"; };
+		80F75A59FF01CC64B720E9DF705711FE /* LICENSE.txt */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		8224169CD8361A3BB68D53A238967A8F /* Pods-FaviconFinder_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-FaviconFinder_Example-umbrella.h"; sourceTree = "<group>"; };
 		83E54A3F599E152CCBAFC8897F5E497C /* FaviconFinder-iOS */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "FaviconFinder-iOS"; path = FaviconFinder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8438DAC514BED7A92346E28A96E93ED1 /* ParseError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParseError.swift; path = Sources/ParseError.swift; sourceTree = "<group>"; };
@@ -321,7 +325,7 @@
 		9A4112FBE53D4451CE36E042D3948608 /* Pods-FaviconFinder_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FaviconFinder_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		9ABA588B2A073D38F62946B9BEF414FC /* FaviconType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FaviconType.swift; sourceTree = "<group>"; };
 		9AFD450145076BFA310955A3F7772BDE /* Tag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Tag.swift; path = Sources/Tag.swift; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A055EA2C6D90C2AABC28671A400F6B9A /* SimpleDictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SimpleDictionary.swift; path = Sources/SimpleDictionary.swift; sourceTree = "<group>"; };
 		A3449BB90781627254A26AE3462B2641 /* DataNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataNode.swift; path = Sources/DataNode.swift; sourceTree = "<group>"; };
 		A3537BA11499C16D61BBB97ECA61BBE9 /* SwiftSoup-macOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "SwiftSoup-macOS-prefix.pch"; path = "../SwiftSoup-macOS/SwiftSoup-macOS-prefix.pch"; sourceTree = "<group>"; };
@@ -338,7 +342,9 @@
 		BB08FAD924516DEBE0DD23CE6A466FEB /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/Parser.swift; sourceTree = "<group>"; };
 		BBC76ADB84C4197270FCDDB1CDBD62CD /* SwiftSoup-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "SwiftSoup-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		BDDBD0CBD546005C62F1B6C5FFD456DE /* TextNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextNode.swift; path = Sources/TextNode.swift; sourceTree = "<group>"; };
+		BE46622327D2DD3C002D02F9 /* FaviconURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconURLRequest.swift; sourceTree = "<group>"; };
 		BE85293150927E90D60487FA6DE069A6 /* Pods-FaviconFinder_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FaviconFinder_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		BEC4954627D1C36A002E82E3 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		C0EDBF0A1EDEAFFEF4B3F049DDC612C0 /* ParseSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParseSettings.swift; path = Sources/ParseSettings.swift; sourceTree = "<group>"; };
 		C20B42400EF692136C361A875D6052B2 /* FaviconFinder-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FaviconFinder-iOS-prefix.pch"; sourceTree = "<group>"; };
 		C22F9A0852BCB0CBDCBEA24426E1596F /* Pods-FaviconFinder_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-FaviconFinder_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -360,7 +366,7 @@
 		DE1C6BDD764751D36451D37373DD1DEF /* Exception.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Exception.swift; path = Sources/Exception.swift; sourceTree = "<group>"; };
 		E0D8C4360D38E64C2138519037A7F855 /* FaviconURL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FaviconURL.swift; sourceTree = "<group>"; };
 		E2171D26BA1499C60846762A42B0FDDB /* HttpStatusException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HttpStatusException.swift; path = Sources/HttpStatusException.swift; sourceTree = "<group>"; };
-		E28B3A3038C0F560B07D186EC2685BC5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		E28B3A3038C0F560B07D186EC2685BC5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E5358E29167092D90DE6D7430D664E7C /* Pods-FaviconFinder_iOS_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-FaviconFinder_iOS_Example-frameworks.sh"; sourceTree = "<group>"; };
 		E5FA55E0DC71B20C04C1218F4829CA26 /* XmlTreeBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XmlTreeBuilder.swift; path = Sources/XmlTreeBuilder.swift; sourceTree = "<group>"; };
 		E835225688132A5057F09D0F6BB9253C /* FaviconFinder-macOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "FaviconFinder-macOS-prefix.pch"; path = "../FaviconFinder-macOS/FaviconFinder-macOS-prefix.pch"; sourceTree = "<group>"; };
@@ -455,7 +461,6 @@
 				9ABA588B2A073D38F62946B9BEF414FC /* FaviconType.swift */,
 				E0D8C4360D38E64C2138519037A7F855 /* FaviconURL.swift */,
 			);
-			name = Types;
 			path = Types;
 			sourceTree = "<group>";
 		};
@@ -561,6 +566,16 @@
 			path = "../Target Support Files/SwiftSoup-iOS";
 			sourceTree = "<group>";
 		};
+		BE46622227D2DD26002D02F9 /* Toolbox */ = {
+			isa = PBXGroup;
+			children = (
+				BE46622327D2DD3C002D02F9 /* FaviconURLRequest.swift */,
+				F30342B51B074B788010EAEE89782426 /* Regex.swift */,
+				BEC4954627D1C36A002E82E3 /* Logger.swift */,
+			);
+			path = Toolbox;
+			sourceTree = "<group>";
+		};
 		BFFF28FBB3B6EB70ABB4B3333EF9ABB0 /* Finders */ = {
 			isa = PBXGroup;
 			children = (
@@ -568,7 +583,6 @@
 				8CC5CDBDAB7FC21CABFD8415D3D690EF /* ICOFaviconFinder.swift */,
 				96240A0C451A586A74E3FF7D225884CE /* WebApplicationManifestFaviconFinder.swift */,
 			);
-			name = Finders;
 			path = Finders;
 			sourceTree = "<group>";
 		};
@@ -632,7 +646,7 @@
 			children = (
 				78636F883C55F6A609AB68DAB9DE7197 /* FaviconFinder.swift */,
 				F205089A5D2D00A81326965DB36EE756 /* FaviconFinderProtocol.swift */,
-				F30342B51B074B788010EAEE89782426 /* Regex.swift */,
+				BE46622227D2DD26002D02F9 /* Toolbox */,
 				BFFF28FBB3B6EB70ABB4B3333EF9ABB0 /* Finders */,
 				254620F91A78C9FCA419C895C08DD464 /* Types */,
 			);
@@ -736,7 +750,6 @@
 				E5FA55E0DC71B20C04C1218F4829CA26 /* XmlTreeBuilder.swift */,
 				BBC7567A00D04E66B4FE7E2775076C41 /* Support Files */,
 			);
-			name = SwiftSoup;
 			path = SwiftSoup;
 			sourceTree = "<group>";
 		};
@@ -1103,12 +1116,14 @@
 				4EBE45BC3EA917E947180C3B7B5CE957 /* FaviconDownloadType.swift in Sources */,
 				F512986DE85DB3B6B7CD5DFE5F8520B1 /* FaviconError.swift in Sources */,
 				A61469FECBCB9427DE6C281F219902CD /* FaviconFinder.swift in Sources */,
+				BE46622527D2DD3C002D02F9 /* FaviconURLRequest.swift in Sources */,
 				B60F314A179BB88C59AB8B90DE904F44 /* FaviconFinder-macOS-dummy.m in Sources */,
 				2627117DB10055A3352D0421AAAEC2BE /* FaviconFinderProtocol.swift in Sources */,
 				9971397993D781C8E72B09FA959933FC /* FaviconType.swift in Sources */,
 				3A77D327C7B0A80E316C7BDD0CA1C6EA /* FaviconURL.swift in Sources */,
 				3E9F78D2FD547BA7A81E1729FCD11AF5 /* HTMLFaviconFinder.swift in Sources */,
 				4D59DF16E37D07FDD0D6404BA10C69C1 /* ICOFaviconFinder.swift in Sources */,
+				BEC4954827D1C36A002E82E3 /* Logger.swift in Sources */,
 				DCA804FC981DFBF2B09E0887A47FE73B /* Regex.swift in Sources */,
 				60FB744978214396F59FEA31EC2367EE /* String+Removals.swift in Sources */,
 				55990104B6AAFBF62F12E11717BA2E8B /* URL+Parsing.swift in Sources */,
@@ -1140,12 +1155,14 @@
 				8A897579CB17CEFCA2847D7FF6A46159 /* FaviconDownloadType.swift in Sources */,
 				FAA7FD4AEDCACBF363DAAEA31722A1AE /* FaviconError.swift in Sources */,
 				7AE2AB649BDE36D28A536C04782EEE73 /* FaviconFinder.swift in Sources */,
+				BE46622427D2DD3C002D02F9 /* FaviconURLRequest.swift in Sources */,
 				9F571F2B001589FB709B5284E15D0FEE /* FaviconFinder-iOS-dummy.m in Sources */,
 				7E55AF09DCC2E64E75EAF7C7A97D52FB /* FaviconFinderProtocol.swift in Sources */,
 				3C469A34046086D06A7B27B7C68441A0 /* FaviconType.swift in Sources */,
 				793ACC9827B01350CC2EF073A9F227CF /* FaviconURL.swift in Sources */,
 				73C844F7B505043945F52BDD3AB11485 /* HTMLFaviconFinder.swift in Sources */,
 				95A6426742B0754AD0C542EE3E340701 /* ICOFaviconFinder.swift in Sources */,
+				BEC4954727D1C36A002E82E3 /* Logger.swift in Sources */,
 				9B811645FBB65E3542BA1746097BDA07 /* Regex.swift in Sources */,
 				994FFDE47DB772471B2A457C614B39BB /* String+Removals.swift in Sources */,
 				5F440CFC5423ABD55FD9B2CE1EF4A684 /* URL+Parsing.swift in Sources */,
@@ -1431,8 +1448,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};

--- a/Example/Pods/Target Support Files/FaviconFinder-iOS/FaviconFinder-iOS-Info.plist
+++ b/Example/Pods/Target Support Files/FaviconFinder-iOS/FaviconFinder-iOS-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.2</string>
+	<string>3.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/FaviconFinder-macOS/FaviconFinder-macOS-Info.plist
+++ b/Example/Pods/Target Support Files/FaviconFinder-macOS/FaviconFinder-macOS-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.2</string>
+	<string>3.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/Tests/FaviconFinderTests.swift
+++ b/Example/Tests/FaviconFinderTests.swift
@@ -16,6 +16,7 @@ class FaviconFinderTests: XCTestCase {
     let appleUrl  = URL(string: "https://apple.com")!
     let realFaviconGeneratorUrl = URL(string: "https://realfavicongenerator.net/blog/apple-touch-icon-the-good-the-bad-the-ugly/")!
     let webApplicationManifestUrl = URL(string: "https://googlechrome.github.io/samples/web-application-manifest/")!
+    let metaRefreshRedirectUrl = URL(string: "https://www.sympy.org/")!
 
     override func setUp() {
 
@@ -55,7 +56,7 @@ class FaviconFinderTests: XCTestCase {
 
     func testFaviconHtmlFind() {
         let expectation = self.expectation(description: "HTML FaviconFind")
-        
+
         FaviconFinder(
             url: self.realFaviconGeneratorUrl,
             preferredType: .html,
@@ -105,6 +106,36 @@ class FaviconFinderTests: XCTestCase {
 
             case .failure(let error):
                 XCTAssert(false, "Failed to download favicon from WebApplicationManifestFile header: \(error.localizedDescription)")
+            }
+        }
+        
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
+    func testCheckForMetaRefreshRedirect() {
+        let expectation = self.expectation(description: "MetaRefreshRedirect HTML FaviconFind")
+
+        FaviconFinder(
+            url: self.metaRefreshRedirectUrl,
+            preferredType: .html,
+            preferences: [:],
+            checkForMetaRefreshRedirect: true,
+            logEnabled: true
+        ).downloadFavicon { result in
+            switch result {
+            case .success(let favicon):
+                
+                // Ensure that our favicon is actually valid
+                XCTAssertTrue(favicon.image.isValidImage)
+
+                // Ensure that our favicon was retrieved from the desired source
+                XCTAssertTrue(favicon.downloadType == .html)
+                
+                // Let the test know that we got our favicon back
+                expectation.fulfill()
+
+            case .failure(let error):
+                XCTAssert(false, "Failed to download favicon from HTML header: \(error.localizedDescription)")
             }
         }
         

--- a/FaviconFinder.podspec
+++ b/FaviconFinder.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "FaviconFinder"
-  s.version      = "3.2.2"
+  s.version      = "3.3.0"
   s.summary      = "A pure Swift library to detect favicons use by a website."
   s.homepage     = "https://github.com/will-lumley/FaviconFinder.git"
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2019 William Lumley <will@lumley.io>
+Copyright (c) 2022 William Lumley <will@lumley.io>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ FaviconFinder handles the dirty work for you and iterates through the numerous l
 
 
 FaviconFinder will:
-- [x] Detect the favicon in the root directory of the URL provided
-- [x] Automatically check if the favicon is located within the root URL if the subdomain failed (Will check `https://site.com/favicon.ico` if `https://subdomain.site.com/favicon.ico` fails)
-- [x] Detect and parse the HTML at the URL for the declaration of the favicon
-- [x] Resolve the favicon URL for you, even if it's a relative URL to the subdomain that you're querying
-- [x] Allow you to prioritise which format of favicon you would like served
-- [x] Detect and parse web application manifest JSON files for favicon locations
+- [x] Detect the favicon in the root directory of the URL provided.
+- [x] Automatically check if the favicon is located within the root URL if the subdomain failed (Will check `https://site.com/favicon.ico` if `https://subdomain.site.com/favicon.ico` fails).
+- [x] Detect and parse the HTML at the URL for the declaration of the favicon.
+- [x] Resolve the favicon URL for you, even if it's a relative URL to the subdomain that you're querying.
+- [x] Allow you to prioritise which format of favicon you would like served.
+- [x] Detect and parse web application manifest JSON files for favicon locations.
+- [x] If you set `checkForMetaRefreshRedirect` to true, FaviconFinder will analyse the HTML for a meta refresh redirect tag. If such a tag is found, the URL in the tag is the URL that will be queried.
 
 To do:
-- [ ] Detect and parse web application Microsoft browser configuration XML
+- [ ] Detect and parse web application Microsoft browser configuration XML.
 
 ## Usage
 
@@ -64,6 +65,7 @@ Similarly, you can specify which JSON key you'd prefer when iterating through th
 
 For the `.ico` download type, you can request FaviconFinder searchs for a filename of your choosing.
 
+In addition, you can also let FaviconFinder know that you'd like the HTML of the website parsed and analysed for a meta-refresh-redirect tag, and query the new URL if found.
 
 Here's how you'd make that request:
 
@@ -76,6 +78,7 @@ Here's how you'd make that request:
             .ico: "favicon.ico",
             .webApplicationManifestFile: FaviconType.launcherIcon4x.rawValue
         ],
+        checkForMetaRefreshRedirect: true,
         logEnabled: true
     ).downloadFavicon { result in
         switch result {

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ FaviconFinder is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'FaviconFinder', '3.2.2'
+pod 'FaviconFinder', '3.3.0'
 ```
 
 ### Carthage
@@ -120,7 +120,7 @@ FaviconFinder is also available through [Carthage](https://github.com/Carthage/C
 it, simply add the following line to your Cartfile:
 
 ```ruby
-github "will-lumley/FaviconFinder" == 3.2.2
+github "will-lumley/FaviconFinder" == 3.3.0
 ```
 
 ### Swift Package Manager
@@ -130,7 +130,7 @@ To install it, simply add the dependency to your Package.Swift file:
 ```swift
 ...
 dependencies: [
-    .package(url: "https://github.com/will-lumley/FaviconFinder.git", from: "3.2.2"),
+    .package(url: "https://github.com/will-lumley/FaviconFinder.git", from: "3.3.0"),
 ],
 targets: [
     .target( name: "YourTarget", dependencies: ["FaviconFinder"]),

--- a/Sources/FaviconFinder/Classes/FaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinder.swift
@@ -25,9 +25,6 @@ public class FaviconFinder: NSObject {
 
     /// The base URL of the site we're trying to extract from
     private var url: URL
-    
-    /// Prints useful states and errors when enabled
-    private var logEnabled: Bool
 
     /// Which download type our user would prefer to use
     private var preferredType: FaviconDownloadType
@@ -35,12 +32,25 @@ public class FaviconFinder: NSObject {
     /// Which preferences the user has for each download type
     private var preferences: [FaviconDownloadType: String]
 
+    /// Indicates if we should check for a meta-refresh-redirect tag in the HTML header
+    private var checkForMetaRefreshRedirect: Bool
+
+    /// Prints useful states and errors when enabled
+    private var logEnabled: Bool
+
     // MARK: - FaviconFinder
 
-    public init(url: URL, preferredType: FaviconDownloadType = .html, preferences: [FaviconDownloadType: String] = [:], logEnabled: Bool = false) {
+    public init(
+        url: URL,
+        preferredType: FaviconDownloadType = .html,
+        preferences: [FaviconDownloadType: String] = [:],
+        checkForMetaRefreshRedirect: Bool = false,
+        logEnabled: Bool = false
+    ) {
         self.url = url
         self.preferredType = preferredType
         self.preferences = preferences
+        self.checkForMetaRefreshRedirect = checkForMetaRefreshRedirect
         self.logEnabled = logEnabled
     }
 
@@ -61,8 +71,14 @@ public class FaviconFinder: NSObject {
         search(downloadType: currentDownloadType)
 
         func search(downloadType: FaviconDownloadType) {
+
             // Setup the download, and get it to search for the URL
-            let downloader = downloadType.downloader(url: self.url, preferredType: self.preferences[downloadType], logEnabled: self.logEnabled)
+            let downloader = downloadType.downloader(
+                url: self.url,
+                preferredType: self.preferences[downloadType],
+                checkForMetaRefreshRedirect: self.checkForMetaRefreshRedirect,
+                logEnabled: self.logEnabled
+            )
             downloader.search(onFind: { [unowned self] result in
                 switch result {
                 case .success(let faviconURL):

--- a/Sources/FaviconFinder/Classes/FaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinder.swift
@@ -5,6 +5,7 @@
 //  Created by William Lumley on 16/10/19.
 //  Copyright © 2019 William Lumley. All rights reserved.
 //
+
 #if targetEnvironment(macCatalyst)
 import UIKit
 public typealias FaviconImage = UIImage
@@ -16,7 +17,6 @@ public typealias FaviconImage = NSImage
 #elseif canImport(UIKit)
 import UIKit
 public typealias FaviconImage = UIImage
-
 #endif
 
 public class FaviconFinder: NSObject {
@@ -113,8 +113,11 @@ private extension FaviconFinder {
      - parameter url: The URL at which we assume an image is at
      */
     private func downloadImage(at url: URL, type: FaviconType, onDownload: @escaping ((_ result: Result<Favicon, FaviconError>) -> Void)) {
-        //Now that we've got the URL of the image, let's download the image
+
+        // Now that we've got the URL of the image, let's download the image
         URLSession.shared.dataTask(with: url, completionHandler: {(data, response, error) in
+
+            // Check for an error
             if let error = error {
                 if self.logEnabled {
                     print("Could NOT download favicon from url: \(url), error: \(error)")
@@ -124,7 +127,7 @@ private extension FaviconFinder {
                 return
             }
             
-            //Make sure our data exists
+            // Make sure our data exists
             guard let data = data else {
                 if self.logEnabled {
                     print("Could NOT get favicon from url: \(self.url), Data was nil.")

--- a/Sources/FaviconFinder/Classes/FaviconFinderProtocol.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinderProtocol.swift
@@ -23,10 +23,13 @@ protocol FaviconFinderProtocol {
     /// A string representation of the class name. Used for logging purposes.
     var description: String { get }
 
+    /// Indicates if we should check for a meta-refresh-redirect tag in the HTML header
+    var checkForMetaRefreshRedirect: Bool { get }
+
     /// An instance of the object we direct logging through.
     var logger: Logger? { get }
 
-    init(url: URL, preferredType: String?, logEnabled: Bool)
+    init(url: URL, preferredType: String?, checkForMetaRefreshRedirect: Bool, logEnabled: Bool)
     func search(onFind: @escaping ((_ result: Result<FaviconURL, FaviconError>) -> Void))
 
 }

--- a/Sources/FaviconFinder/Classes/FaviconFinderProtocol.swift
+++ b/Sources/FaviconFinder/Classes/FaviconFinderProtocol.swift
@@ -9,12 +9,24 @@ import Foundation
 
 protocol FaviconFinderProtocol {
 
+    /// The URL of the website we're querying the Favicon for
     var url: URL { get set }
+
+    /// Whether or not we this Finder will log information to the console
     var logEnabled: Bool { get set }
+
+    /// The preferred type of Favicon. This is dependant on type.
+    /// For example, `ICOFaviconFinder` the `preferredType` is a filename, for `WebApplicationManifestFaviconFinder` the
+    /// `preferredType` is the desired key in the JSON file, etc.
     var preferredType: String { get set }
 
-    init(url: URL, preferredType: String?, logEnabled: Bool)
+    /// A string representation of the class name. Used for logging purposes.
+    var description: String { get }
 
+    /// An instance of the object we direct logging through.
+    var logger: Logger? { get }
+
+    init(url: URL, preferredType: String?, logEnabled: Bool)
     func search(onFind: @escaping ((_ result: Result<FaviconURL, FaviconError>) -> Void))
 
 }

--- a/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
@@ -25,6 +25,8 @@ class HTMLFaviconFinder: FaviconFinderProtocol {
 
     var url: URL
     var preferredType: String
+    var checkForMetaRefreshRedirect: Bool
+
     var logEnabled: Bool
     var description: String
     var logger: Logger?
@@ -34,19 +36,23 @@ class HTMLFaviconFinder: FaviconFinderProtocol {
 
     // MARK: - FaviconFinder
 
-    required init(url: URL, preferredType: String?, logEnabled: Bool) {
+    required init(url: URL, preferredType: String?, checkForMetaRefreshRedirect: Bool, logEnabled: Bool) {
         self.url = url
         self.preferredType = preferredType ?? FaviconType.appleTouchIcon.rawValue // Default to `appleTouchIcon` type if user does not present us with one
+        self.checkForMetaRefreshRedirect = checkForMetaRefreshRedirect
+
         self.logEnabled = logEnabled
         self.description = NSStringFromClass(HTMLFaviconFinder.self)
-
         self.logger = Logger(faviconFinder: self)
     }
 
     func search(onFind: @escaping ((Result<FaviconURL, FaviconError>) -> Void)) {
 
         // Download the web page at our URL
-        FaviconURLRequest.dataTask(with: self.url, checkForMetaRefreshRedirect: true) { data, response, error in
+        FaviconURLRequest.dataTask(
+            with: self.url,
+            checkForMetaRefreshRedirect: self.checkForMetaRefreshRedirect
+        ) { data, response, error in
 
             // Make sure our data exists
             guard let data = data else {

--- a/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
@@ -7,21 +7,25 @@
 
 import Foundation
 
-class ICOFaviconFinder: FaviconFinderProtocol {
+class ICOFaviconFinder: FaviconFinderProtocol {    
 
     // MARK: - Properties
 
     var url: URL
     var preferredType: String
+    var checkForMetaRefreshRedirect: Bool
+
     var logEnabled: Bool
     var description: String
     var logger: Logger?
 
     // MARK: - FaviconFinder
 
-    required init(url: URL, preferredType: String?, logEnabled: Bool) {
+    required init(url: URL, preferredType: String?, checkForMetaRefreshRedirect: Bool, logEnabled: Bool) {
         self.url = url
         self.preferredType = preferredType ?? "favicon.ico" // Default to the filename of "favicon.ico" if user does not present us with one
+        self.checkForMetaRefreshRedirect = checkForMetaRefreshRedirect
+
         self.logEnabled = logEnabled
         self.description = NSStringFromClass(Self.self)
         self.logger = Logger(faviconFinder: self)

--- a/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
@@ -9,14 +9,22 @@ import Foundation
 
 class ICOFaviconFinder: FaviconFinderProtocol {
 
+    // MARK: - Properties
+
     var url: URL
     var preferredType: String
     var logEnabled: Bool
+    var description: String
+    var logger: Logger?
+
+    // MARK: - FaviconFinder
 
     required init(url: URL, preferredType: String?, logEnabled: Bool) {
         self.url = url
-        self.preferredType = preferredType ?? "favicon.ico" //Default to the filename of "favicon.ico" if user does not present us with one
+        self.preferredType = preferredType ?? "favicon.ico" // Default to the filename of "favicon.ico" if user does not present us with one
         self.logEnabled = logEnabled
+        self.description = NSStringFromClass(Self.self)
+        self.logger = Logger(faviconFinder: self)
     }
 
     func search(onFind: @escaping ((Result<FaviconURL, FaviconError>) -> Void)) {
@@ -29,7 +37,7 @@ class ICOFaviconFinder: FaviconFinderProtocol {
             onFind(.failure(.failedToFindFavicon))
             return
         }
-        
+
         // Switch to the background thread, as we'll be doing some networking
         DispatchQueue.global().async {
 

--- a/Sources/FaviconFinder/Classes/Finders/WebApplicationManifestFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/WebApplicationManifestFaviconFinder.swift
@@ -9,7 +9,6 @@ import Foundation
 
 #if canImport(SwiftSoup)
 import SwiftSoup
-
 #endif
 
 class WebApplicationManifestFaviconFinder: FaviconFinderProtocol {
@@ -26,14 +25,17 @@ class WebApplicationManifestFaviconFinder: FaviconFinderProtocol {
     var url: URL
     var preferredType: String
     var logEnabled: Bool
+    var description: String
+    var logger: Logger?
 
-    /// The preferred type of favicon we're after
-    //var preferredType: String? = FaviconType.appleTouchIcon.rawValue
+    // MARK: - FaviconFinder
 
     required init(url: URL, preferredType: String?, logEnabled: Bool) {
         self.url = url
         self.preferredType = preferredType ?? FaviconType.launcherIcon4x.rawValue //Default to `launcherIcon4x` type if user does not present us with one
         self.logEnabled = logEnabled
+        self.description = NSStringFromClass(Self.self)
+        self.logger = Logger(faviconFinder: self)
     }
 
     func search(onFind: @escaping ((Result<FaviconURL, FaviconError>) -> Void)) {
@@ -41,31 +43,25 @@ class WebApplicationManifestFaviconFinder: FaviconFinderProtocol {
         let strongSelf = self
 
         // Download the web page at our URL
-        URLSession.shared.dataTask(with: `self`.url, completionHandler: { [unowned self] (data, response, error) in
-            
+        FaviconURLRequest.dataTask(with: `self`.url, checkForMetaRefreshRedirect: true) { [unowned self] data, response, error in
+
             // Make sure our data exists
             guard let data = data else {
-                if self.logEnabled {
-                    print("Could NOT get favicon from url: \(self.url), Data was nil.")
-                }
+                self.logger?.print("Could NOT get favicon from url: \(self.url), Data was nil.")
                 onFind(.failure(.emptyData))
                 return
             }
-            
+
             // Make sure we can parse the response into a string
             guard let html = String(data: data, encoding: String.Encoding.utf8) else {
-                if self.logEnabled {
-                    print("Could NOT get favicon from url: \(self.url), could not parse HTML.")
-                }
+                self.logger?.print("Could NOT get favicon from url: \(self.url), could not parse HTML.")
                 onFind(.failure(.failedToParseHTML))
                 return
             }
-            
+
             // Get a hold of where our manifest URL is
             guard let manifestURL = strongSelf.manifestUrl(from: html) else {
-                if self.logEnabled {
-                    print("Could NOT get manifest file from url: \(self.url), failed to parse favicon from WebApplicationManifestFile.")
-                }
+                self.logger?.print("Could NOT get manifest file from url: \(self.url), failed to parse favicon from WebApplicationManifestFile.")
                 onFind(.failure(.failedToFindWebApplicationManifestFile))
                 return
             }
@@ -75,26 +71,24 @@ class WebApplicationManifestFaviconFinder: FaviconFinderProtocol {
 
                 // Make sure we can find a favicon in our retrieved manifest data
                 guard let faviconURL = strongSelf.faviconURL(from: manifestData) else {
-                    if self.logEnabled {
-                        print("Could NOT get favicon from url: \(self.url), failed to parse favicon from manifest data.")
-                    }
+                    self.logger?.print("Could NOT get favicon from url: \(self.url), failed to parse favicon from manifest data.")
                     onFind(.failure(.failedToDownloadFavicon))
                     return
                 }
                 
                 // We found our favicon, let's download it
-                if self.logEnabled {
-                    print("Extracted favicon: \(faviconURL.url.absoluteString)")
-                }
+                Logger.print(self.logEnabled, "Extracted favicon: \(faviconURL.url.absoluteString)")
                 onFind(.success(faviconURL))
             }, onError: { error in
                 onFind(.failure(error))
             })
 
-        }).resume()
+        }
     }
 
 }
+
+// MARK: - Private Functions
 
 private extension WebApplicationManifestFaviconFinder {
 
@@ -109,23 +103,17 @@ private extension WebApplicationManifestFaviconFinder {
             htmlOpt = try SwiftSoup.parse(htmlStr)
         }
         catch let error {
-            if logEnabled {
-                print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
-            }
+            self.logger?.print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
             return nil
         }
         
         guard let html = htmlOpt else {
-            if logEnabled {
-                print("Could NOT parse HTML from string: \(htmlStr)")
-            }
+            self.logger?.print("Could NOT parse HTML from string: \(htmlStr)")
             return nil
         }
         
         guard let head = html.head() else {
-            if logEnabled {
-                print("Could NOT parse HTML head from string: \(htmlStr)")
-            }
+            self.logger?.print("Could NOT parse HTML head from string: \(htmlStr)")
             return nil
         }
 
@@ -155,17 +143,13 @@ private extension WebApplicationManifestFaviconFinder {
                 }
             }
             catch let error {
-                if logEnabled {
-                    print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
-                }
+                self.logger?.print("Could NOT parse HTML due to error: \(error). HTML: \(htmlStr)")
                 continue
             }
         }
 
         guard let fileReference = fileReference else {
-            if logEnabled {
-                print("Could NOT find any HTML href tag that points to a manifest file")
-            }
+            self.logger?.print("Could NOT find any HTML href tag that points to a manifest file")
             return nil
         }
 
@@ -212,12 +196,12 @@ private extension WebApplicationManifestFaviconFinder {
 
             //If we can convert the NSURLResponse to an NSHTTPURLResponse
             guard let urlResponse = response as? HTTPURLResponse else {
-                print("Could not create URLResponse from request: \(request): \(String(describing: error))")
+                self.logger?.print("Could not create URLResponse from request: \(request): \(String(describing: error))")
                 onError(.failedToDownloadWebApplicationManifestFile)
                 return
             }
 
-            print("Received URL response of \(urlResponse.statusCode) for URL: \(request.url!.absoluteString)")
+            self.logger?.print("Received URL response of \(urlResponse.statusCode) for URL: \(request.url!.absoluteString)")
 
             guard let data = data else {
                 onError(.emptyData)

--- a/Sources/FaviconFinder/Classes/Toolbox/FaviconURLRequest.swift
+++ b/Sources/FaviconFinder/Classes/Toolbox/FaviconURLRequest.swift
@@ -1,0 +1,123 @@
+//
+//  FaviconURLRequest.swift
+//  Pods
+//
+//  Created by William Lumley on 5/3/2022.
+//
+
+import Foundation
+
+#if canImport(SwiftSoup)
+import SwiftSoup
+#endif
+
+class FaviconURLRequest {
+
+    static func dataTask(
+        with url: URL,
+        checkForMetaRefreshRedirect: Bool = false,
+        completionHandler: @escaping (Data?, URLResponse?, Error?) -> ()
+    ) {
+        URLSession.shared.dataTask(with: url) { data, urlResponse, error in
+            // If we're supposed to check for the meta-refresh-redirect,
+            // parse the HTML and check for a meta-refresh-redirect
+            if checkForMetaRefreshRedirect {
+
+                do {
+                    // Make sure our data exists
+                    guard let data = data else {
+                        completionHandler(data, urlResponse, error)
+                        return
+                    }
+
+                    // Make sure we can parse the response into a string
+                    guard let htmlStr = String(data: data, encoding: .utf8) else {
+                        completionHandler(data, urlResponse, error)
+                        return
+                    }
+
+                    // Parse the string into a workable HTML object
+                    let html = try SwiftSoup.parse(htmlStr)
+
+                    // Get the head of the HTML
+                    guard let head = html.head() else {
+                        completionHandler(data, urlResponse, error)
+                        return
+                    }
+
+                    // Get all meta-refresh-redirect tag
+                    let httpEquivs = try head.getElementsByAttribute("http-equiv")
+                    guard let httpEquiv = try httpEquivs.whereAttr("http-equiv", equals: "refresh") else {
+                        completionHandler(data, urlResponse, error)
+                        return
+                    }
+
+                    // Get the URL
+                    var redirectURLStr = try httpEquiv.attr("content")
+
+                    // Remove the 0;URL=
+                    redirectURLStr = redirectURLStr.replacingOccurrences(of: "0;URL=", with: "")
+
+                    // Determine if this is a whole new URL, or something we should append to the current one
+                    let brandNewURL = Regex.testForHttpsOrHttp(input: redirectURLStr)
+
+                    // If this is a brand new URL
+                    if brandNewURL {
+                        guard let redirectURL = URL(string: redirectURLStr) else {
+                            return
+                        }
+
+                        URLSession.shared.dataTask(with: redirectURL) { data, urlResponse, error in
+                            completionHandler(data, urlResponse, error)
+                        }.resume()
+                    }
+
+                    // If this something we should append to our current URL
+                    else {
+                        let needsPrependingSlash = url.absoluteString.last != "/" && redirectURLStr.first != "/"
+                        if needsPrependingSlash {
+                            redirectURLStr = "\(url.absoluteString)/\(redirectURLStr)"
+                        }
+                        else {
+                            redirectURLStr = "\(url.absoluteString)\(redirectURLStr)"
+                        }
+
+                        guard let redirectURL = URL(string: redirectURLStr) else {
+                            return
+                        }
+
+                        URLSession.shared.dataTask(with: redirectURL) { data, urlResponse, error in
+                            completionHandler(data, urlResponse, error)
+                        }.resume()
+                    }
+                }
+                catch {
+                    completionHandler(data, urlResponse, error)
+                    return
+                }
+
+            }
+            // We're not supposed to check for the meta-refresh-redirect, so just return the data
+            else {
+                completionHandler(data, urlResponse, error)
+            }
+        }.resume()
+    }
+
+}
+
+// MARK: - SwiftSoup.Elements
+
+private extension Elements {
+
+    func whereAttr(_ attribute: String, equals value: String) throws -> Element? {
+        for element in self {
+            if try element.attr(attribute) == value {
+                return element
+            }
+        }
+
+        return nil
+    }
+
+}

--- a/Sources/FaviconFinder/Classes/Toolbox/Logger.swift
+++ b/Sources/FaviconFinder/Classes/Toolbox/Logger.swift
@@ -1,0 +1,38 @@
+//
+//  Logger.swift
+//  Pods
+//
+//  Created by William Lumley on 4/3/2022.
+//
+
+import Foundation
+
+class Logger {
+
+    var faviconFinder: FaviconFinderProtocol?
+
+    init() {
+
+    }
+
+    init(faviconFinder: FaviconFinderProtocol) {
+        self.faviconFinder = faviconFinder
+    }
+
+    func print(_ string: String) {
+        guard let faviconFinder = self.faviconFinder else {
+            return
+        }
+
+        if faviconFinder.logEnabled {
+            Swift.print("[\(faviconFinder.description)] \(string)")
+        }
+    }
+
+    static func print(_ actuallyLog: Bool, _ string: String) {
+        if actuallyLog {
+            Swift.print(string)
+        }
+    }
+
+}

--- a/Sources/FaviconFinder/Classes/Toolbox/Regex.swift
+++ b/Sources/FaviconFinder/Classes/Toolbox/Regex.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal class Regex {
+class Regex {
 
     private var expression: NSRegularExpression?
     private var pattern: String
@@ -35,6 +35,7 @@ internal class Regex {
 }
 
 //MARK: - Static Functions
+
 extension Regex {
 
     public static func testForHttpsOrHttp(input: String) -> Bool {

--- a/Sources/FaviconFinder/Classes/Types/FaviconDownloadType.swift
+++ b/Sources/FaviconFinder/Classes/Types/FaviconDownloadType.swift
@@ -44,14 +44,34 @@ internal extension FaviconDownloadType {
 
 internal extension FaviconDownloadType {
 
-    func downloader(url: URL, preferredType: String?, logEnabled: Bool) -> FaviconFinderProtocol {
+    func downloader(
+        url: URL,
+        preferredType: String?,
+        checkForMetaRefreshRedirect: Bool,
+        logEnabled: Bool
+    ) -> FaviconFinderProtocol {
         switch self {
         case .ico:
-            return ICOFaviconFinder(url: url, preferredType: preferredType, logEnabled: logEnabled)
+            return ICOFaviconFinder(
+                url: url,
+                preferredType: preferredType,
+                checkForMetaRefreshRedirect: checkForMetaRefreshRedirect,
+                logEnabled: logEnabled
+            )
         case .html:
-            return HTMLFaviconFinder(url: url, preferredType: preferredType, logEnabled: logEnabled)
+            return HTMLFaviconFinder(
+                url: url,
+                preferredType: preferredType,
+                checkForMetaRefreshRedirect: checkForMetaRefreshRedirect,
+                logEnabled: logEnabled
+            )
         case .webApplicationManifestFile:
-            return WebApplicationManifestFaviconFinder(url: url, preferredType: preferredType, logEnabled: logEnabled)
+            return WebApplicationManifestFaviconFinder(
+                url: url,
+                preferredType: preferredType,
+                checkForMetaRefreshRedirect: checkForMetaRefreshRedirect,
+                logEnabled: logEnabled
+            )
         }
     }
 


### PR DESCRIPTION
Allows developers to indicate a boolean flag, which indicates if the initial response should have it's HTML parsed and checked for a meta refresh redirect tag. 
If such a tag is found, a new URL request is sent out and the contents of that request will be the one that is parsed.