### PR TITLE
Change order of shortcutIcon check

### DIFF
--- a/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
@@ -188,11 +188,6 @@ private extension HTMLFaviconFinder {
             return (icon: icon, type: FaviconType(rawValue: icon.rel)!)
         }
 
-        // Check for shortcutIcon type
-        else if let icon = icons.first(where: { FaviconType(rawValue: $0.rel) == .shortcutIcon }) {
-            return (icon: icon, type: FaviconType(rawValue: icon.rel)!)
-        }
-
         // Check for icon type
         let iconTypeIcons = icons.enumerated().filter({FaviconType(rawValue: $1.rel) == .icon})
         
@@ -204,6 +199,11 @@ private extension HTMLFaviconFinder {
 
         if let firstSize = sizes.first {
             let icon = icons[firstSize.index]
+            return (icon: icon, type: FaviconType(rawValue: icon.rel)!)
+        }
+
+        // Check for shortcutIcon type last since it's often a low quality .ico file
+        if let icon = icons.first(where: { FaviconType(rawValue: $0.rel) == .shortcutIcon }) {
             return (icon: icon, type: FaviconType(rawValue: icon.rel)!)
         }
 


### PR DESCRIPTION
It seems pretty common for "shortcut icon" types to reference a low res .ico file (e.g. YouTube), while "icon" types will offer higher resolutions. This change prioritized "icon" over "shortcut icon" in an effort to get the url of the highest res icon possible.

This is a re-application (`git cherry-pick`) of #51, which seems to have been overwritten since it was merged.