### PR TITLE
[GI-58] Removed hardcoding of utf-8 encoding

### DIFF
--- a/Example/FaviconFinder/ExampleViewController.swift
+++ b/Example/FaviconFinder/ExampleViewController.swift
@@ -28,7 +28,7 @@ class ExampleViewController: NSViewController
             print("Not a valid URL: \(urlStr)")
             return
         }
-        
+
         Task {
             do {
                 let favicon = try await FaviconFinder(url: url, preferredType: .html, preferences: [

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		BAC3414F9AE9CDFC61E3743077CC52E0 /* SwiftSoup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE35DEEAAE4A4C2D430A4D83B2381AF /* SwiftSoup.swift */; };
 		BB112C7C5E2160D57903035AAFBE8D80 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575C8AE3BB2470696D264C739FDB2597 /* Comment.swift */; };
 		BBFE8C5233C99DE8F929CDB54CAFD3AB /* TokeniserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55302528FE9453EB3BB90D1FA877126 /* TokeniserState.swift */; };
+		BE580AA62878458E00A7DE22 /* URLResponse+StringEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE580AA52878458E00A7DE22 /* URLResponse+StringEncoding.swift */; };
+		BE580AA72878458E00A7DE22 /* URLResponse+StringEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE580AA52878458E00A7DE22 /* URLResponse+StringEncoding.swift */; };
 		BFCCF2DE0A5602A78E3E16627C1B5BC6 /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3716937BCAB6F0D36BD18C22AAD75E3C /* Elements.swift */; };
 		C2539A8CC965879B0AA0AD8EC3FAEA3B /* TextNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDBD0CBD546005C62F1B6C5FFD456DE /* TextNode.swift */; };
 		C311A6106D14B9D7AD0A90F338DEBA2A /* Favicon.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEFFC9694B469A8940F0FE33D3D83CB /* Favicon.swift */; };
@@ -343,6 +345,7 @@
 		BB08FAD924516DEBE0DD23CE6A466FEB /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/Parser.swift; sourceTree = "<group>"; };
 		BBC76ADB84C4197270FCDDB1CDBD62CD /* SwiftSoup-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "SwiftSoup-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		BDDBD0CBD546005C62F1B6C5FFD456DE /* TextNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextNode.swift; path = Sources/TextNode.swift; sourceTree = "<group>"; };
+		BE580AA52878458E00A7DE22 /* URLResponse+StringEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+StringEncoding.swift"; sourceTree = "<group>"; };
 		BE85293150927E90D60487FA6DE069A6 /* Pods-FaviconFinder_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-FaviconFinder_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		C0EDBF0A1EDEAFFEF4B3F049DDC612C0 /* ParseSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParseSettings.swift; path = Sources/ParseSettings.swift; sourceTree = "<group>"; };
 		C20B42400EF692136C361A875D6052B2 /* FaviconFinder-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FaviconFinder-iOS-prefix.pch"; sourceTree = "<group>"; };
@@ -513,6 +516,7 @@
 			children = (
 				2D3F4C278068F1ACA53057E091EC6C01 /* String+Removals.swift */,
 				769A528A74D952AB3DF9A651F09A4239 /* URL+Parsing.swift */,
+				BE580AA52878458E00A7DE22 /* URLResponse+StringEncoding.swift */,
 			);
 			name = Extensions;
 			path = Sources/FaviconFinder/Extensions;
@@ -1107,6 +1111,7 @@
 				B352CBEFF1D5D48DC2AC56AA004DAA1A /* Favicon.swift in Sources */,
 				285A613A30FF908698EE769CED60B53E /* FaviconDownloadType.swift in Sources */,
 				0C3AAFB7413BCA1E0369486A2C23BA06 /* FaviconError.swift in Sources */,
+				BE580AA62878458E00A7DE22 /* URLResponse+StringEncoding.swift in Sources */,
 				4FEE1242F5DC2FCA259C441CA1DDAA6A /* FaviconFinder.swift in Sources */,
 				D4D3F8E560D894F23C823EDBAEB3F0DA /* FaviconFinder-iOS-dummy.m in Sources */,
 				89CDF006596D8FF26CCF4D8353A0F736 /* FaviconFinderProtocol.swift in Sources */,
@@ -1138,6 +1143,7 @@
 				C311A6106D14B9D7AD0A90F338DEBA2A /* Favicon.swift in Sources */,
 				AEF54242A5C1B6EFEB0A82A48C059FF8 /* FaviconDownloadType.swift in Sources */,
 				47C06781755059B950864A3C7102C08B /* FaviconError.swift in Sources */,
+				BE580AA72878458E00A7DE22 /* URLResponse+StringEncoding.swift in Sources */,
 				9F141D2248B5D64C36AE46C0CCF77E83 /* FaviconFinder.swift in Sources */,
 				714421C28AED549E3D74F2503F984F89 /* FaviconFinder-macOS-dummy.m in Sources */,
 				5F768F0324BCDDBAD07621B4A3A61233 /* FaviconFinderProtocol.swift in Sources */,

--- a/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
@@ -48,10 +48,13 @@ class HTMLFaviconFinder: FaviconFinderProtocol {
 
     func search() async throws -> FaviconURL {
         // Download the web page at our URL
-        let data = try await FaviconURLRequest.dataTask(with: self.url, checkForMetaRefreshRedirect: self.checkForMetaRefreshRedirect).0
+        let urlResponse = try await FaviconURLRequest.dataTask(with: self.url, checkForMetaRefreshRedirect: self.checkForMetaRefreshRedirect)
+
+        let data = urlResponse.0
+        let response = urlResponse.1
 
         // Make sure we can parse the response into a string
-        guard let html = String(data: data, encoding: .utf8) else {
+        guard let html = String(data: data, encoding: response.encoding) else {
             throw FaviconError.failedToParseHTML
         }
 

--- a/Sources/FaviconFinder/Classes/Finders/WebApplicationManifestFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/WebApplicationManifestFaviconFinder.swift
@@ -44,10 +44,13 @@ class WebApplicationManifestFaviconFinder: FaviconFinderProtocol {
 
     func search() async throws -> FaviconURL {
         // Download the web page at our URL
-        let data = try await FaviconURLRequest.dataTask(with: self.url, checkForMetaRefreshRedirect: self.checkForMetaRefreshRedirect).0
+        let urlResponse = try await FaviconURLRequest.dataTask(with: self.url, checkForMetaRefreshRedirect: self.checkForMetaRefreshRedirect)
+
+        let data = urlResponse.0
+        let response = urlResponse.1
         
         // Make sure we can parse the response into a string
-        guard let html = String(data: data, encoding: .utf8) else {
+        guard let html = String(data: data, encoding: response.encoding) else {
             self.logger?.print("Could NOT get favicon from url: \(self.url), could not parse HTML.")
             throw FaviconError.failedToParseHTML
         }

--- a/Sources/FaviconFinder/Classes/Toolbox/FaviconURLRequest.swift
+++ b/Sources/FaviconFinder/Classes/Toolbox/FaviconURLRequest.swift
@@ -21,7 +21,7 @@ class FaviconURLRequest {
 
         if checkForMetaRefreshRedirect {
             // Make sure we can parse the response into a string
-            guard let htmlStr = String(data: data, encoding: .utf8) else {
+            guard let htmlStr = String(data: data, encoding: response.encoding) else {
                 return (data, response)
             }
 

--- a/Sources/FaviconFinder/Extensions/URLResponse+StringEncoding.swift
+++ b/Sources/FaviconFinder/Extensions/URLResponse+StringEncoding.swift
@@ -1,0 +1,24 @@
+//
+//  URLRequest+StringEncoding.swift
+//  Pods
+//
+//  Created by William Lumley on 8/7/2022.
+//
+
+import Foundation
+
+extension URLResponse {
+
+    var encoding: String.Encoding {
+        guard let rawName = self.textEncodingName else {
+            return .utf8
+        }
+
+        let cfName = CFStringConvertIANACharSetNameToEncoding(rawName as CFString)
+        let constant = CFStringConvertEncodingToNSStringEncoding(cfName)
+
+        let encoded = String.Encoding(rawValue: constant)
+        return encoded
+    }
+
+}


### PR DESCRIPTION
`URLResponse's used to be assumed to be `.utf8`, however that is not the case.
This PR introduces functionality that reads the responses text encoding and uses that format, instead of hardcoding to `.utf8` every time.