### PR TITLE
Fetch URL Only

### DIFF
--- a/Example/FaviconFinder/ExampleViewController.swift
+++ b/Example/FaviconFinder/ExampleViewController.swift
@@ -31,10 +31,14 @@ class ExampleViewController: NSViewController
 
         Task {
             do {
-                let favicon = try await FaviconFinder(url: url, preferredType: .html, preferences: [
-                    FaviconDownloadType.html: FaviconType.appleTouchIcon.rawValue,
-                    FaviconDownloadType.ico: "favicon.ico"
-                ]).downloadFavicon()
+                let favicon = try await FaviconFinder(
+                    url: url,
+                    preferredType: .html,
+                    preferences: [
+                        FaviconDownloadType.ico: "favicon.ico",
+                        FaviconDownloadType.html: FaviconType.appleTouchIcon.rawValue
+                    ]
+                ).downloadFavicon()
 
                 print("URL of Favicon: \(favicon.url)")
                 DispatchQueue.main.async {
@@ -43,6 +47,12 @@ class ExampleViewController: NSViewController
 
             } catch let error {
                 print("Error: \(error)")
+
+                let alert = NSAlert()
+                alert.messageText = "Error"
+                alert.informativeText = "\(error)"
+
+                alert.runModal()
             }
         }
     }

--- a/Example/FaviconFinder/Info.plist
+++ b/Example/FaviconFinder/Info.plist
@@ -34,7 +34,8 @@
                 <true/>
             </dict>
         </dict>
-    </dict>	<key>NSMainNibFile</key>
+    </dict>
+    <key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>

--- a/Example/FaviconFinder/Info.plist
+++ b/Example/FaviconFinder/Info.plist
@@ -22,7 +22,19 @@
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>NSMainNibFile</key>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>foodmate.net</key>
+            <dict>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
+        </dict>
+    </dict>	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>

--- a/Example/Tests/FaviconFinderTests.swift
+++ b/Example/Tests/FaviconFinderTests.swift
@@ -164,7 +164,7 @@ class FaviconFinderTests: XCTestCase {
     }
 
     func testNoImageDownload() {
-        let expectation = self.expectation(description: "HTML FaviconFind")
+        let expectation = self.expectation(description: "No Image Download")
 
         Task {
             do {

--- a/Example/Tests/FaviconFinderTests.swift
+++ b/Example/Tests/FaviconFinderTests.swift
@@ -168,6 +168,35 @@ class FaviconFinderTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
+    func testNoImageDownload() {
+        let expectation = self.expectation(description: "HTML FaviconFind")
+
+        Task {
+            do {
+                let favicon = try await FaviconFinder(
+                    url: self.realFaviconGeneratorUrl,
+                    preferredType: .html,
+                    preferences: [:],
+                    downloadImage: false,
+                    logEnabled: true
+                ).downloadFavicon()
+
+                // Ensure that our favicon is NOT valid
+                XCTAssertFalse(favicon.image.isValidImage)
+
+                // Ensure the URL was passed
+                XCTAssertEqual(favicon.url.absoluteString, "https://realfavicongenerator.net/blog/wp-content/uploads/fbrfg/apple-touch-icon.png")
+
+                // Let the test know that we got our favicon back
+                expectation.fulfill()
+            } catch let error {
+                XCTAssert(false, "Failed to download favicon from HTML header: \(error.localizedDescription)")
+            }
+        }
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
 }
 
 private extension FaviconImage {

--- a/Example/Tests/FaviconFinderTests.swift
+++ b/Example/Tests/FaviconFinderTests.swift
@@ -17,7 +17,7 @@ class FaviconFinderTests: XCTestCase {
     let realFaviconGeneratorUrl = URL(string: "https://realfavicongenerator.net/blog/apple-touch-icon-the-good-the-bad-the-ugly/")!
     let webApplicationManifestUrl = URL(string: "https://googlechrome.github.io/samples/web-application-manifest/")!
     let metaRefreshRedirectUrl = URL(string: "https://www.sympy.org/")!
-    let nonUtf8EncodedWebsite = URL(string: "https://www.qq.com/")!
+    let nonUtf8EncodedWebsite = URL(string: "http://foodmate.net")!
 
     override func setUp() {
 
@@ -145,12 +145,7 @@ class FaviconFinderTests: XCTestCase {
 
         Task {
             do {
-                let favicon = try await FaviconFinder(
-                    url: self.nonUtf8EncodedWebsite,
-                    preferredType: .html,
-                    preferences: [:],
-                    logEnabled: true
-                ).downloadFavicon()
+                let favicon = try await FaviconFinder(url: self.nonUtf8EncodedWebsite).downloadFavicon()
 
                 // Ensure that our favicon is actually valid
                 XCTAssertTrue(favicon.image.isValidImage)

--- a/FaviconFinder.podspec
+++ b/FaviconFinder.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "FaviconFinder"
-  s.version      = "4.0.1"
+  s.version      = "4.1.0"
   s.summary      = "A pure Swift library to detect favicons use by a website."
   s.homepage     = "https://github.com/will-lumley/FaviconFinder.git"
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ FaviconFinder uses simple syntax to allow you to easily download the favicon you
 
 ## Advanced Usage
 
+### Preferential Downloading
+
 However if you're the type to want to have some fine-tuned control over what sort of favicon's we're after, you can do so.
 
 FaviconFinder allows you to specify which download type you'd prefer (HTML, actual file, or web application manifest file), and then allows you to specify which favicon type you'd prefer for each download type.
@@ -93,6 +95,34 @@ This allows you to control:
 - When iterating through each download type, what sub-type to look for. For the HTML download type, this allows you to prioritise different "rel" types. For the file.ico type, this allows you to choose the filename.
 
 If your desired download type doesn't exist for your URL (ie. you requested the favicon that exists as a file but there's no file), FaviconFinder will automatically try all other methods of favicon storage for you. 
+
+### Fetching without Downloading
+
+If you would like FaviconFinder to fetch the favicon URL without also executing an image download, you can do so with the following parameter:
+
+```swift
+    do {
+        let favicon = try await FaviconFinder(
+            url: url, 
+            preferredType: .html, 
+            preferences: [
+                .html: FaviconType.appleTouchIcon.rawValue,
+                .ico: "favicon.ico",
+                .webApplicationManifestFile: FaviconType.launcherIcon4x.rawValue
+            ],
+            downloadImage: false
+        ).downloadFavicon()
+
+        print("URL of Favicon: \(favicon.url)")
+        DispatchQueue.main.async {
+            self.imageView.image = favicon.image
+        }
+    } catch let error {
+        print("Error: \(error)")
+    }
+```
+
+When the parameter `downloadImage` is set to false, an image download will not occur and only the URL will be returned (wrapped in a Favicon struct).
 
 ## Example Project
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ FaviconFinder is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'FaviconFinder', '4.0.1'
+pod 'FaviconFinder', '4.1.0'
 ```
 
 ### Carthage
@@ -118,7 +118,7 @@ FaviconFinder is also available through [Carthage](https://github.com/Carthage/C
 it, simply add the following line to your Cartfile:
 
 ```ruby
-github "will-lumley/FaviconFinder" == 4.0.1
+github "will-lumley/FaviconFinder" == 4.1.0
 ```
 
 ### Swift Package Manager
@@ -128,7 +128,7 @@ To install it, simply add the dependency to your Package.Swift file:
 ```swift
 ...
 dependencies: [
-    .package(url: "https://github.com/will-lumley/FaviconFinder.git", from: "4.0.1"),
+    .package(url: "https://github.com/will-lumley/FaviconFinder.git", from: "4.1.0"),
 ],
 targets: [
     .target( name: "YourTarget", dependencies: ["FaviconFinder"]),

--- a/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
@@ -32,8 +32,6 @@ class ICOFaviconFinder: FaviconFinderProtocol {
     }
 
     func search() async throws -> FaviconURL {
-        // TODO: Check that there's an actual image at the path.
-
         // If there's not, try the root instead.
         // Then, remove the RootICO finder and type.
         let baseUrl = URL(string: "/", relativeTo: self.url)

--- a/Sources/FaviconFinder/Classes/Types/FaviconURL.swift
+++ b/Sources/FaviconFinder/Classes/Types/FaviconURL.swift
@@ -7,12 +7,26 @@
 
 import Foundation
 
-internal struct FaviconURL {
+struct FaviconURL {
 
     /// The url of the .ico or HTML page, of where the favicon was found
     public let url: URL
 
     /// The type of favicon we extracted
     public let type: FaviconType
+
+}
+
+extension FaviconURL {
+
+    var emptyImage: Favicon {
+        Favicon(
+            image: FaviconImage(),
+            data: Data(),
+            url: self.url,
+            type: self.type,
+            downloadType: .html
+        )
+    }
 
 }


### PR DESCRIPTION
This PR enables functionality that lets you fetch the URL of the favicon only - so you can fetch the favicons source without executing a download.