### PR TITLE
Logger creates retain cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Carthage/Build
 # `pod install` in .travis.yml
 #
 # Pods/
+.build/

--- a/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/HTMLFaviconFinder.swift
@@ -43,7 +43,9 @@ class HTMLFaviconFinder: FaviconFinderProtocol {
 
         self.logEnabled = logEnabled
         self.description = NSStringFromClass(HTMLFaviconFinder.self)
-        self.logger = Logger(faviconFinder: self)
+        if logEnabled {
+            self.logger = Logger(faviconFinder: self)
+        }
     }
 
     func search() async throws -> FaviconURL {

--- a/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/ICOFaviconFinder.swift
@@ -28,7 +28,9 @@ class ICOFaviconFinder: FaviconFinderProtocol {
 
         self.logEnabled = logEnabled
         self.description = NSStringFromClass(Self.self)
-        self.logger = Logger(faviconFinder: self)
+        if logEnabled {
+            self.logger = Logger(faviconFinder: self)
+        }
     }
 
     func search() async throws -> FaviconURL {

--- a/Sources/FaviconFinder/Classes/Finders/WebApplicationManifestFaviconFinder.swift
+++ b/Sources/FaviconFinder/Classes/Finders/WebApplicationManifestFaviconFinder.swift
@@ -39,7 +39,9 @@ class WebApplicationManifestFaviconFinder: FaviconFinderProtocol {
         
         self.logEnabled = logEnabled
         self.description = NSStringFromClass(Self.self)
-        self.logger = Logger(faviconFinder: self)
+        if logEnabled {
+            self.logger = Logger(faviconFinder: self)
+        }
     }
 
     func search() async throws -> FaviconURL {


### PR DESCRIPTION
While debugging memory usage is our app I noticed the FaviconFinder Logger creates a retain cycle.

<img width="1268" alt="Screenshot 2022-08-02 at 15 35 15" src="https://user-images.githubusercontent.com/11800807/182388226-c7013b46-af9c-483a-9a7e-936f43422d00.png">

The MR contains a quick fix to skip instantiating a logger when logging is disabled, but you might want to take a deeper look and fix the actual cause.

