### PR TITLE
Add configuration to pass prefetched html

### DIFF
--- a/Sources/FaviconFinder/FaviconFinder+Configuration.swift
+++ b/Sources/FaviconFinder/FaviconFinder+Configuration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftSoup
 
 public extension FaviconFinder {
 
@@ -22,16 +23,20 @@ public extension FaviconFinder {
         /// Indicates if we should check for a meta-refresh-redirect tag in the HTML header
         public let checkForMetaRefreshRedirect: Bool
 
+        public let prefetchedHTML: Document?
+
         // MARK: - Lifecycle
 
         public init(
             preferredSource: FaviconSourceType = .html,
             preferences: [FaviconSourceType : String] = [:],
-            checkForMetaRefreshRedirect: Bool = false
+            checkForMetaRefreshRedirect: Bool = false,
+            prefetchedHTML: Document? = nil
         ) {
             self.preferredSource = preferredSource
             self.preferences = preferences
             self.checkForMetaRefreshRedirect = checkForMetaRefreshRedirect
+            self.prefetchedHTML = prefetchedHTML
         }
     }
 

--- a/Sources/FaviconFinder/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Finders/HTMLFaviconFinder.swift
@@ -38,21 +38,27 @@ class HTMLFaviconFinder: FaviconFinderProtocol {
     }
     
     func find() async throws -> [FaviconURL] {
-        // Download the web page at our URL
-        let response = try await FaviconURLSession.dataTask(
-            with: self.url,
-            checkForMetaRefreshRedirect: self.configuration.checkForMetaRefreshRedirect
-        )
+        let html: Document
 
-        let data = response.data
+        if let prefetchedHTML = configuration.prefetchedHTML {
+            html = prefetchedHTML
+        } else {
+            // Download the web page at our URL
+            let response = try await FaviconURLSession.dataTask(
+                with: self.url,
+                checkForMetaRefreshRedirect: self.configuration.checkForMetaRefreshRedirect
+            )
 
-        // Make sure we can parse the response into a string
-        guard let htmlStr = String(data: data, encoding: response.textEncoding) else {
-            throw FaviconError.failedToParseHTML
+            let data = response.data
+
+            // Make sure we can parse the response into a string
+            guard let htmlStr = String(data: data, encoding: response.textEncoding) else {
+                throw FaviconError.failedToParseHTML
+            }
+
+            // Turn our HTML string as an XML document we can check out
+            html = try SwiftSoup.parse(htmlStr)
         }
-
-        // Turn our HTML string as an XML document we can check out
-        let html = try SwiftSoup.parse(htmlStr)
 
         // Get just the head of our HTML document
         guard let head = html.head() else {


### PR DESCRIPTION
Hi!

This package looks great and fits my needs, however I am using this in parallel with code I wrote to fetch the title/description from the HTML and wanted to optimize network usage.  This PR adds an optional configuration for passing `prefetchedHTML`, a SwiftSoup `Document` that has already been fetched.  This removes 1-2 unnecessary network requests if you already have fetched a page.

Ideally the fetched data in `HTMLFaviconFinder` would be reused in `WebApplicationManifestFaviconFinder` even when `prefetchedHTML` isn't specified to reduce 1 network call, but I couldn't find a simple way to add that.