### PR TITLE
Allow FaviconFinder task to be cancelled

### DIFF
--- a/Sources/FaviconFinder/FaviconFinder.swift
+++ b/Sources/FaviconFinder/FaviconFinder.swift
@@ -61,7 +61,12 @@ public extension FaviconFinder {
                     if faviconURLs.count > 0 {
                         return faviconURLs
                     }
-                } catch {
+                }
+                catch is CancellationError {
+                    // The user has cancelled this, let's bubble this up
+                    throw CancellationError()
+                }
+                catch {
                     print("Failed to find Favicon [\(error)]. Trying next source type.")
                 }
             }

--- a/Sources/FaviconFinder/FaviconFinder.swift
+++ b/Sources/FaviconFinder/FaviconFinder.swift
@@ -61,12 +61,10 @@ public extension FaviconFinder {
                     if faviconURLs.count > 0 {
                         return faviconURLs
                     }
-                }
-                catch is CancellationError {
+                } catch is CancellationError {
                     // The user has cancelled this, let's bubble this up
                     throw CancellationError()
-                }
-                catch {
+                } catch {
                     print("Failed to find Favicon [\(error)]. Trying next source type.")
                 }
             }

--- a/Sources/FaviconFinder/Finders/MockFaviconFinder.swift
+++ b/Sources/FaviconFinder/Finders/MockFaviconFinder.swift
@@ -1,0 +1,53 @@
+//
+//  MockFaviconFinder.swift
+//  Pods
+//
+//  Created by William Lumley on 26/5/21.
+//
+
+import Foundation
+
+class MockFaviconFinder: FaviconFinderProtocol {
+
+    // MARK: - Properties
+
+    var url: URL
+    var configuration: FaviconFinder.Configuration
+
+    var preferredType: String {
+        "test.png"
+    }
+
+    /// The amount of time, in seconds, that we'll wait before returning our `find()` result
+    var duration = 5
+
+    /// The error that we'll return in our `find()`
+    var error: FaviconError?
+
+    // MARK: - FaviconFinder
+
+    required init(url: URL, configuration: FaviconFinder.Configuration) {
+        self.url = url
+        self.configuration = configuration
+    }
+
+    func find() async throws -> [FaviconURL] {
+        try await Task.sleep(nanoseconds: UInt64(self.duration) * 1_000_000_000)
+
+        // Throw the error if we're supposed to
+        if let error {
+            throw error
+        }
+
+        // Otherwise return a URL
+        return [
+            .init(
+                source: URL(string: "https://google.com")!,
+                format: .appleTouchIcon,
+                sourceType: .html,
+                sizeTag: nil
+            )
+        ]
+    }
+
+}

--- a/Sources/FaviconFinder/Types/FaviconSourceType.swift
+++ b/Sources/FaviconFinder/Types/FaviconSourceType.swift
@@ -12,6 +12,9 @@ public enum FaviconSourceType: CaseIterable {
     case html
     case ico
     case webApplicationManifestFile
+
+    /// This is used exclusively for testing
+    case mock
 }
 
 extension FaviconSourceType {
@@ -59,6 +62,11 @@ extension FaviconSourceType {
             )
         case .webApplicationManifestFile:
             return WebApplicationManifestFaviconFinder(
+                url: url,
+                configuration: configuration
+            )
+        case .mock:
+            return MockFaviconFinder(
                 url: url,
                 configuration: configuration
             )

--- a/Tests/FaviconFinderTests/FaviconFinderTests.swift
+++ b/Tests/FaviconFinderTests/FaviconFinderTests.swift
@@ -96,7 +96,7 @@ class FaviconFinderTests: XCTestCase {
     }
 
     func testCancel() async throws {
-        let faviconFinder = try await FaviconFinder(
+        let faviconFinder = FaviconFinder(
             url: .google,
             configuration: .init(preferredSource: .mock)
         )

--- a/macOSFaviconFinderExample/macOSFaviconFinderExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOSFaviconFinderExample/macOSFaviconFinderExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,60 @@
 {
+  "originHash" : "4bbbf259247beb09353593099b3916fb88f244ff37749f45cf6db719e0e64267",
   "pins" : [
+    {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "c9c3df6ab812de32bae61fc0cd1bf6d45170ebf0",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "fd4df99170f5e9d7cf9aa8312aa8506e0e7a44e7",
+        "version" : "0.35.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "82a453c2dfa335c7e778695762438dfe72b328d2",
+        "version" : "600.0.0-prerelease-2024-07-24"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "103e585b56170e4d22c2f979da9932356a340083"
+      }
+    },
     {
       "identity" : "swiftsoup",
       "kind" : "remoteSourceControl",
@@ -8,7 +63,34 @@
         "revision" : "f83c097597094a04124eb6e0d1e894d24129af87",
         "version" : "2.7.0"
       }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
+        "version" : "5.1.3"
+      }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
# 📖 Brief Description
Just like most comedians from the 90s, a FaviconFinder can now be cancelled!
The finding functionality is wrapped within a `Task` which can be cancelled from a public interface in FaviconFinder.