### PR TITLE
Failure of Favicon download will trigger next type of Favicon to be downloaded

### DIFF
--- a/Sources/FaviconFinder/FaviconFinder.swift
+++ b/Sources/FaviconFinder/FaviconFinder.swift
@@ -119,9 +119,10 @@ public extension Array where Element == FaviconURL {
     func download() async throws -> [Favicon] {
         var favicons = [Favicon]()
         for url in self {
-            favicons.append(
-                try await Favicon(url: url)
-            )
+            guard let favicon = try? await Favicon(url: url) else {
+                continue
+            }
+            favicons.append(favicon)
         }
 
         return favicons


### PR DESCRIPTION
# 📖 Brief Description
Currently if you have an array of `FaviconURL` and download them, if one of them fails, the whole process fails. This PR takes @yangliu-1995's advice and will iterate to the next one.