### PR TITLE
Fix Memory Leaks on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 #if os(Linux)
 let dependencies: [PackageDescription.Package.Dependency] = [
     // URLSession on Linux is notoriously unreliable and freezes, so this is used instead (only for Linux)
-    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.9.0"),
+    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.22.0"),
 
     // SwiftSoup is used to parse the HTML tree
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.7")

--- a/Sources/FaviconFinder/Toolbox/FaviconURLSession.swift
+++ b/Sources/FaviconFinder/Toolbox/FaviconURLSession.swift
@@ -79,10 +79,10 @@ private extension FaviconURLSession {
         request.headers = headers
 
         // Send the request
-        let response = try await httpClient.execute(request, timeout: .seconds(30))
+        let response = try await httpClient.execute(request, timeout: .seconds(15))
 
         // Collect the response body
-        let byteBuffer = try await response.body.collect(upTo: Int.max)
+        let byteBuffer = try await response.body.collect(upTo: 2048 * 1024) // 2MB
         let data = Data(buffer: byteBuffer)
 
         // Check for meta-refresh redirect if needed


### PR DESCRIPTION
I've made three changes that address a memory leak that was causing FaviconFinder to take up infinite memory, and crash servers running on Linux.

1. I'd recommend making this first change, bumping async-http-client from 1.9.0 to 1.22.0. There have been a lot of changes since 1.9.0 that are worth pulling in, if not for stability alone.

2. I've also lowered the default response timeout duration from 30 to 15 seconds. You would have more evidence of what the best default is, but ideally this could be made configurable, because I don't think it's worth waiting 30 seconds for a favicon to load.

3. Previously `response.body.collect(upTo:)` was set to `Int.max`, I've defaulted it to `2048 *  1024` bytes (2MB). This is what was causing the runaway memory issues on some websites, because the Linux variant of FaviconFinder using async-http-client was requesting `Int.max` bytes, even on servers that did not have 4 GB of ram. (Testable with this [link](https://atlantic.ctvnews.ca/caught-me-by-surprise-rare-blue-frog-spotted-in-nova-scotia-1.7008979).) 