### PR TITLE
[FEATURE] Sort `FaviconURL` by size based on metadata without downloading image data

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+The Code of Conduct governs how we behave in public or in private
+whenever the project will be judged by our actions.
+We expect it to be honored by everyone who represents the project
+officially or informally,
+claims affiliation with the project,
+or participates directly.
+
+We strive to:
+
+* **Be open**: We invite anybody to participate in any aspect of our projects.
+  Our community is open, and any responsibility can be carried
+  by any contributor who demonstrates the required capacity and competence.
+* **Be empathetic**: We work together to resolve conflict,
+  assume good intentions,
+  and do our best to act in an empathic fashion.
+  By understanding that humanity drops a few packets in online interactions,
+  and adjusting accordingly,
+  we can create a comfortable environment for everyone to share their ideas.
+* **Be collaborative**: We prefer to work transparently
+  and to involve interested parties early on in the process.
+  Wherever possible, we work closely with others in the open source community
+  to coordinate our efforts.
+* **Be decisive**: We expect participants in the project to resolve disagreements constructively.
+  When they cannot, we escalate the matter to structures
+  with designated leaders to arbitrate and provide clarity and direction.
+* **Be responsible**: We hold ourselves accountable for our actions.
+  When we make mistakes, we take responsibility for them.
+  When we need help, we reach out to others.
+  When it comes time to move on from a project,
+  we take the proper steps to ensure that others can pick up where we left off.
+
+This code is not exhaustive or complete.
+It serves to distill our common understanding of a
+collaborative, shared environment and goals.
+We expect it to be followed in spirit as much as in the letter.
+
+---
+
+*The Alamofire Software Foundation Code of Conduct is licensed under the [Creative Commons Attribution-Share Alike 3.0 License](https://creativecommons.org/licenses/by-sa/3.0/us/).*
+
+*Some of the ideas and wording for the statements above were based on work by   [Mozilla](https://wiki.mozilla.org/Code_of_Conduct/Draft), [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct), and [Twitter](https://github.com/twitter/code-of-conduct). We thank them for their work and contributions to the open source community.*

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -38,6 +38,4 @@ We expect it to be followed in spirit as much as in the letter.
 
 ---
 
-*The Alamofire Software Foundation Code of Conduct is licensed under the [Creative Commons Attribution-Share Alike 3.0 License](https://creativecommons.org/licenses/by-sa/3.0/us/).*
-
-*Some of the ideas and wording for the statements above were based on work by   [Mozilla](https://wiki.mozilla.org/Code_of_Conduct/Draft), [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct), and [Twitter](https://github.com/twitter/code-of-conduct). We thank them for their work and contributions to the open source community.*
+*Some of the ideas and wording for the statements above were based on work by   [Alamofire](https://github.com/Alamofire/Foundation/blob/master/CONDUCT.md), [Mozilla](https://wiki.mozilla.org/Code_of_Conduct/Draft), [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct), and [Twitter](https://github.com/twitter/code-of-conduct). We thank them for their work and contributions to the open source community.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,9 @@ To submit a pull request (PR), please follow these steps:
 - **Documentation**: Update or create documentation for any new features or changes.
 
 ## License  By contributing to FaviconFinder, you agree that your contributions will be licensed under the MIT license.
+
+## Code of Conduct
+                                                           
+The Code of Conduct governs how we behave in public or in private whenever the project will be judged by our actions. We expect it to be honored by everyone who contributes to this project.
+
+See [CONDUCT.md](https://github.com/will-lumley/FaviconFinder/CONDUCT.md) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,9 @@ To submit a pull request (PR), please follow these steps:
 - **Tests**: Ensure that your code is covered by unit tests and that they all pass before submitting.
 - **Documentation**: Update or create documentation for any new features or changes.
 
-## License  By contributing to FaviconFinder, you agree that your contributions will be licensed under the MIT license.
+## License
+
+By contributing to FaviconFinder, you agree that your contributions will be licensed under the MIT license.
 
 ## Code of Conduct
                                                            

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to FaviconFinder
+
+Thank you for your interest in contributing to FaviconFinder! We appreciate your help in making this project better.
+
+## How to Contribute
+
+### Reporting Issues
+
+If you've found a bug or an issue, please submit it [here](https://github.com/will-lumley/FaviconFinder/issues). When submitting an issue, include the following:
+- A clear and descriptive title.
+- Steps to reproduce the issue.
+- Expected vs. actual results.
+- Any relevant logs, screenshots, or environment details.
+
+### Suggesting Features
+
+We welcome feature requests! When suggesting a feature, include:
+- A detailed description of the feature.
+- Why it would be useful.
+- Any potential drawbacks.
+
+### Pull Requests
+
+To submit a pull request (PR), please follow these steps:
+1. Fork the repo and create your branch:
+    ```bash
+    git checkout -b feature/my-new-feature
+    ```
+2. Ensure your code passes all tests and doesn't raise any SwiftLint warnings.
+3. Submit your PR, and link to any relevant issues or discussions.
+
+## Coding Guidelines
+
+- **Code Style**: Please follow Swift best practices and use meaningful names for variables and functions.
+- **Tests**: Ensure that your code is covered by unit tests and that they all pass before submitting.
+- **Documentation**: Update or create documentation for any new features or changes.
+
+## License  By contributing to FaviconFinder, you agree that your contributions will be licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/apple/swift-package-manager"><img src="https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat" alt="SPM Compatible"></a>
-  <img src="https://img.shields.io/badge/Swift-5.5-orange.svg" alt="Swift 5.5">
+  <img src="https://img.shields.io/badge/Swift-6.0-orange.svg" alt="Swift 6.0">
   <a href="https://twitter.com/wlumley95">
     <img src="https://img.shields.io/badge/twitter-@wlumley95-blue.svg?style=flat" alt="Twitter">
   </a>
@@ -65,20 +65,20 @@ FaviconFinder works with UIKit, SwiftUI, AppKit, and macOS Catalyst.
 
 FaviconFinder also supports Linux as a platform, and I have re-implemented parts of FaviconFinder to ensure that Linux is treated as a first-class platform.
 It's important to note that Swift on Linux doesn't natively support any `Image` format, so when you call download, the `data` itself is downloaded but there's no
-image type to cast the data to. Also dueo to this, `largest()` and `smallest()` aren't effective on Linux.
+image type to cast the data to. Also due to this, `largest()` and `smallest()` aren't effective on Linux.
 
 
 ## Advanced Usage & Configuration
 
 ### Preferential Downloading
 
-However if you're the type to want to have some fine-tuned control over what sort of favicon's we're after, you can do so.
+Now if you're the type to want to have some fine-tuned control over what sort of favicon's we're after, boy is this the library for you.
 
 FaviconFinder allows you to specify which download type you'd prefer (HTML, actual file, or web application manifest file), and then allows you to specify which favicon type you'd prefer for each download type.
 
-For example, you can specify that you'd prefer a HTML tag favicon, with the type of `appleTouchIcon`. FaviconFinder will then search through the HTML favicon tags for the `appleTouchIcon` type. If it cannot find the `appleTouchIcon` type, it will search for the other HTML favicon tag types.   
+For example, you can specify that you'd prefer a favicon that is declared within the from the HTML header file, and then within that request the the `appleTouchIcon` type. FaviconFinder will then search through the HTML favicon tags for the `appleTouchIcon` type. If it cannot find the `appleTouchIcon` type, it will search for the other HTML favicon tag types.   
 
-If the URL does not have a HTML tag that specifies the favicon, FaviconFinder will default to other download types, and will search the URL for each favicon download type until it finds one, or it'll return an error. 
+If the URL does not have a HTML tag that specifies the favicon, FaviconFinder will default to other download types, and will search the source for each favicon download type until it finds one, or it'll return an error. 
 
 Just like how you can specify which HTML favicon tag you'd prefer, you can set which filename you'd prefer when search for actual files. 
 
@@ -152,6 +152,37 @@ Here is how you would use it.
     self.imageView.image = favicon.image
 ```
 
+### Pre-Fetched HTML
+
+FaviconFinder allows you to pass a pre-fetched HTML document to avoid downloading the HTML multiple times or if you already have the HTML content available from another source. You can use the prefetchedHTML property in the configuration to pass this document.
+
+We use the Document type of SwiftSoup, as it has amazing HTML storing and parsing capabilities, allowing for easy manipulation and traversal of the document tree.
+
+This feature is useful when:
+- You have already downloaded the HTML document elsewhere in your app and want to reuse it.
+- You’re working with local HTML files or custom documents.
+- You want to optimise performance by reducing the number of HTTP requests.
+
+Here's how you can use it:
+
+```swift
+import SwiftSoup
+
+// Assuming you have already fetched and parsed the HTML
+let htmlString = "<html><head>...</head></html>"
+let document = try SwiftSoup.parse(htmlString)
+
+let favicon = try await FaviconFinder(
+    url: url,
+    configuration: .init(prefetchedHTML: document)
+)
+    .fetchFaviconURLs()
+    .download()
+    .largest()
+
+self.imageView.image = favicon.image
+```
+
 ## Example Projects
 
 To run the example project, clone the repo, and open the example Xcode Project in either the `iOSFaviconFinderExample`, or `macOSFaviconFinderExample`, depending on your build target.
@@ -159,6 +190,10 @@ To run the example project, clone the repo, and open the example Xcode Project i
 Alternatively, if you're using this for a Linux project, you can open the example Swift Project located in `LinuxFaviconFinderExample`.
 
 ## Requirements
+
+FaviconFinder is now written with Swift 6.0. This means we get to use `Swift Testing` over `XCTest`, but more importantly means FaviconFinder is now data-race safe and adheres to strict concurrency.
+
+Swift 6.0 is supported from version `5.1.0` and up. If you need FaviconFinder in Swift 5.9 and below, please use version `5.0.4`.
 
 FaviconFinder now supports await/async concurrency, as seen in the examples below. Due to this, the most up to date version of FaviconFinder requires iOS 15.0 and macOS 12.0.
 If you need to support older versions of iOS or macOS, version 3.3.0 of FaviconFinder uses closures to call back the success/failure instead of await/async concurrency.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ FaviconFinder will:
 - [x] Detect and parse web application manifest JSON files for favicon locations.
 - [x] Automatically check if the favicon is located within the root URL if the subdomain failed (Will check `https://site.com/favicon.ico` if `https://subdomain.site.com/favicon.ico` fails).
 - [x] If you set `checkForMetaRefreshRedirect` to true, FaviconFinder will analyse the HTML for a meta refresh redirect tag. If such a tag is found, the URL in the tag is the URL that will be queried.
+- [x] Sort favicons by size using the sizeTag metadata (either in HTML or the web app manifest) without downloading the images, allowing you to identify the largest or smallest favicon efficiently.
+- [x] Support pre-fetched HTML documents, so you can reuse HTML you’ve already downloaded instead of fetching it again.
+- [x] Cross-platform support for macOS, iOS, and Linux - and supports SwiftUI and UIKit, ensuring seamless integration across multiple environments and applications.
 
 To do:
 - [ ] Detect and parse web application Microsoft browser configuration XML.
@@ -183,6 +186,47 @@ let favicon = try await FaviconFinder(
 self.imageView.image = favicon.image
 ```
 
+### Sorting Favicon URLs by Size Without Downloading
+
+FaviconFinder includes functionality that allows you to determine the largest or smallest favicon available without needing to download all the images first. This is useful for optimising performance when you only need the largest or smallest image based on size metadata.
+
+By inspecting the size tags provided in the HTML or web application manifest file, FaviconFinder can sort through the available favicon URLs and select the one with the largest or smallest dimensions.
+
+To find the largest or smallest favicon URL without downloading the images:
+
+```swift
+let faviconURL = try await FaviconFinder(url: url)
+    .fetchFaviconURLs()
+    .largest()  // or .smallest()
+
+print("Largest Favicon URL: \(faviconURL.source)")
+```
+
+This will return the largest or smallest favicon based on the metadata in the size tag.
+
+Once you have identified the largest or smallest favicon URL, you can then proceed to download the actual image:
+
+```swift
+let largestFavicon = try await FaviconFinder(url: url)
+    .fetchFaviconURLs()
+    .largest()
+    .download()
+
+self.imageView.image = largestFavicon.image
+```
+
+There are pros and cons to using this approach.
+
+Advantages
+- No need to download all the images to determine which one is largest or smallest.
+- Optimises performance by focusing on the favicons that meet your size requirements.
+
+Limitations
+- The sizeTag metadata must be accurately set by the source (HTML or web app manifest).
+- The actual image size may differ if the source configuration is incorrect.
+
+This functionality allows you to efficiently sort favicon URLs by size and download only the favicons you need, making it a powerful tool for handling favicons in an optimised manner.
+
 ## Example Projects
 
 To run the example project, clone the repo, and open the example Xcode Project in either the `iOSFaviconFinderExample`, or `macOSFaviconFinderExample`, depending on your build target.
@@ -196,18 +240,18 @@ FaviconFinder is now written with Swift 6.0. This means we get to use `Swift Tes
 Swift 6.0 is supported from version `5.1.0` and up. If you need FaviconFinder in Swift 5.9 and below, please use version `5.0.4`.
 
 FaviconFinder now supports await/async concurrency, as seen in the examples below. Due to this, the most up to date version of FaviconFinder requires iOS 15.0 and macOS 12.0.
-If you need to support older versions of iOS or macOS, version 3.3.0 of FaviconFinder uses closures to call back the success/failure instead of await/async concurrency.
+If you need to support older versions of iOS or macOS, version `3.3.0` of FaviconFinder uses closures to call back the success/failure instead of await/async concurrency.
 
 ## Installation
 
 ### Swift Package Manager
-FaviconFinder is also available through [Swift Package Manager](https://github.com/apple/swift-package-manager). 
+FaviconFinder is available through [Swift Package Manager](https://github.com/apple/swift-package-manager). 
 To install it, simply add the dependency to your Package.Swift file:
 
 ```swift
 ...
 dependencies: [
-    .package(url: "https://github.com/will-lumley/FaviconFinder.git", from: "5.0.4"),
+    .package(url: "https://github.com/will-lumley/FaviconFinder.git", from: "5.1.0"),
 ],
 targets: [
     .target( name: "YourTarget", dependencies: ["FaviconFinder"]),

--- a/Sources/FaviconFinder/FaviconFinder+Configuration.swift
+++ b/Sources/FaviconFinder/FaviconFinder+Configuration.swift
@@ -26,6 +26,8 @@ public extension FaviconFinder {
         /// The HTTP headers we'll pass along to our HTTP request
         public let httpHeaders: [String: String?]?
 
+        /// An optional prefetched HTML document that you can pass if you'd rather not FaviconFinder
+        /// do the HTML document downloading, or you have a local document.
         public let prefetchedHTML: Document?
 
         // MARK: - Lifecycle

--- a/Sources/FaviconFinder/FaviconFinder.swift
+++ b/Sources/FaviconFinder/FaviconFinder.swift
@@ -37,10 +37,11 @@ public extension FaviconFinder {
     /// Will iterate through each of the source types we have available to us, and
     /// search for the websites favicon through there.
     ///
-    /// - Important: If the user has set a source preference in the Configuration, then
+    /// - important: If the user has set a source preference in the Configuration, then
     /// that source will be moved to the front of the queue in the hopes the preference can be
     /// made.
-    /// - Returns: An array of FaviconURLs that contain the location of all the users favicons
+    /// - returns: An array of FaviconURLs that contain the location of all the users favicons
+    ///
     func fetchFaviconURLs() async throws -> [FaviconURL] {
         // Cancel any previous task
         self.cancel()
@@ -66,7 +67,6 @@ public extension FaviconFinder {
             // Iterate through each source, trying to find the favicon
             // in each source until we find it.
             for source in sources {
-                print("Trying with [\(source)] source")
                 do {
                     let finder = source.finder(url: url, configuration: config)
                     let faviconURLs = try await finder.find()
@@ -80,10 +80,10 @@ public extension FaviconFinder {
                         // Map this to Swift's `CancellationError`
                         throw CancellationError()
                     } else {
-                        print("Failed to find Favicon [\(error)]. Trying next source type.")
+                        // print("Failed to find Favicon [\(error)]. Trying next source type.")
                     }
                 } catch {
-                    print("Failed to find Favicon [\(error)]. Trying next source type.")
+                    // print("Failed to find Favicon [\(error)]. Trying next source type.")
                 }
             }
 
@@ -100,193 +100,6 @@ public extension FaviconFinder {
     /// Cancels the ongoing favicon fetch task, if any.
     func cancel() {
         self.currentTask?.cancel()
-    }
-
-}
-
-// MARK: - Private
-
-private extension FaviconFinder {
-
-}
-
-// MARK: - [FaviconURL]
-
-public extension Array where Element == FaviconURL {
-
-    /// Will iterate over each `FaviconURL` and analyse the `inferredSize`, and returns
-    /// the largest one.
-    ///
-    /// Notably, calling `largest()` on an array of `FaviconURL` instead of on an array of
-    /// `Favicon` means you can extrapolate the largest image without having to download all of them.
-    /// This comes with the drawbacks of
-    ///     1. Only being able to use this function appropriately if the source has set the sizeTags, either in the
-    ///       HTML or the WebApplicationManifestFile.
-    ///     2. Not being 100% certain, as the size in the sizeTags and the actual true size may be different due
-    ///       to the source being configured incorrectly.
-    ///
-    /// However there are plently of use cases where these drawbacks are worth it to get the largest image without
-    /// having to download them all, so here we are.
-    ///
-    /// - returns: A `FaviconURL` from the array of `FaviconURL`s that we deem to be the largest.
-    ///
-    func largest() async throws -> FaviconURL {
-        let largestFavicon = self
-            // Return true  if `a` is less than `b`
-            // Return false if `b` is less than `a`
-            .max { faviconA, faviconB in
-                guard let sizeA = faviconA.inferredSize else {
-                    return true
-                }
-                guard let sizeB = faviconB.inferredSize else {
-                    return false
-                }
-
-                let sizeAValue = sizeA.width * sizeA.height
-                let sizeBValue = sizeB.width * sizeB.height
-
-                return sizeAValue < sizeBValue
-            }
-
-        guard let largestFavicon else {
-            throw FaviconError.failedToFindFavicon
-        }
-        return largestFavicon
-    }
-
-    /// Will iterate over each `FaviconURL` and analyse the `inferredSize`, and returns
-    /// the smallest one.
-    ///
-    /// Notably, calling `smallest()` on an array of `FaviconURL` instead of on an array of
-    /// `Favicon` means you can extrapolate the smallest image without having to download all of them.
-    /// This comes with the drawbacks of
-    ///     1. Only being able to use this function appropriately if the source has set the sizeTags, either in the
-    ///       HTML or the WebApplicationManifestFile.
-    ///     2. Not being 100% certain, as the size in the sizeTags and the actual true size may be different due
-    ///       to the source being configured incorrectly.
-    ///
-    /// However there are plently of use cases where these drawbacks are worth it to get the smallest image without
-    /// having to download them all, so here we are.
-    ///
-    /// - returns: A `FaviconURL` from the array of `FaviconURL`s that we deem to be the smallest.
-    ///
-    func smallest() async throws -> FaviconURL {
-        let smallestFavicon = self
-            // Return true  if `a` is less than `b`
-            // Return false if `b` is less than `a`
-            .max { faviconA, faviconB in
-                guard let sizeA = faviconA.inferredSize else {
-                    return true
-                }
-                guard let sizeB = faviconB.inferredSize else {
-                    return false
-                }
-
-                let sizeAValue = sizeA.width * sizeA.height
-                let sizeBValue = sizeB.width * sizeB.height
-
-                return sizeAValue > sizeBValue
-            }
-
-        guard let smallestFavicon else {
-            throw FaviconError.failedToFindFavicon
-        }
-        return smallestFavicon
-
-    }
-
-    /// Will iterate over each FaviconURL in our array, and initiate
-    /// a `Favicon` instance after downloading the image data
-    /// at the source specified by the FaviconURL.
-    ///
-    /// - returns: An array of `Favicon`, each containing the downloaded image data.
-    ///
-    func download() async throws -> [Favicon] {
-        var favicons = [Favicon]()
-        for url in self {
-            guard let favicon = try? await Favicon(url: url) else {
-                continue
-            }
-            favicons.append(favicon)
-        }
-
-        return favicons
-    }
-
-}
-
-// MARK: - [Favicon]
-
-/// Something important to note is that these functions require the `FaviconImage` to be downloaded (using the
-/// `download()` function first so comparison can take place.
-/// This is generally not advised unless you are in a situation where the size isn't indicated via HTML tags or WMAF
-/// tags.
-///
-///
-public extension Array where Element == Favicon {
-
-    /// Will pull the first `Favicon` from the array
-    ///
-    /// - Important: Why not jus use the `.first` computed variable that comes
-    /// with arrays? Because that variable returns `nil` if the array is empty. Throughout
-    /// this project, we throw an error if something has gone wrong rather than silently fail. To
-    /// ensure that consistency can be kept, this function is provided to developers and an
-    /// error will be thrown if the array is empty.
-    ///
-    /// - returns: The first `Favicon` in this array
-    ///
-    func first() throws -> Favicon {
-        guard let first = self.first else {
-            throw FaviconError.failedToFindFavicon
-        }
-
-        return first
-    }
-
-    /// Will pull the `Favicon` from the array that has the largest image size
-    ///
-    /// - returns: The `Favicon` that has the largest image
-    ///
-    func largest() throws -> Favicon {
-
-        // Find the Favicon with the largest image
-        let first = try self.first()
-        let largestImage = try self.reduce(first) { current, next in
-            guard let currentImage = current.image, let nextImage = next.image else {
-                throw FaviconError.faviconImageIsNotDownloaded
-            }
-
-            if currentImage.size > nextImage.size {
-                return current
-            } else {
-                return next
-            }
-        }
-
-        return largestImage
-    }
-
-    /// Will pull the `Favicon` from the array that has the smallest image size
-    ///
-    /// - returns: The `Favicon` that has the smallest image
-    ///
-    func smallest() throws -> Favicon {
-
-        // Find the Favicon with the smallest image
-        let first = try self.first()
-        let smallestImage = try self.reduce(first) { current, next in
-            guard let currentImage = current.image, let nextImage = next.image else {
-                throw FaviconError.faviconImageIsNotDownloaded
-            }
-
-            if currentImage.size < nextImage.size {
-                return current
-            } else {
-                return next
-            }
-        }
-
-        return smallestImage
     }
 
 }

--- a/Sources/FaviconFinder/Finders/MockFaviconFinder.swift
+++ b/Sources/FaviconFinder/Finders/MockFaviconFinder.swift
@@ -45,7 +45,19 @@ class MockFaviconFinder: FaviconFinderProtocol {
                 source: URL(string: "https://google.com")!,
                 format: .appleTouchIcon,
                 sourceType: .html,
-                sizeTag: nil
+                sizeTag: "100x140"
+            ),
+            .init(
+                source: URL(string: "https://apple.com")!,
+                format: .appleTouchIcon,
+                sourceType: .html,
+                sizeTag: "100x90"
+            ),
+            .init(
+                source: URL(string: "https://facebook.com")!,
+                format: .appleTouchIcon,
+                sourceType: .html,
+                sizeTag: "100x90"
             )
         ]
     }

--- a/Sources/FaviconFinder/Finders/WebApplicationManifestFaviconFinder.swift
+++ b/Sources/FaviconFinder/Finders/WebApplicationManifestFaviconFinder.swift
@@ -77,9 +77,15 @@ class WebApplicationManifestFaviconFinder: FaviconFinderProtocol {
 
         // And turn it into something we can work with
         let faviconURLs = rawIcons.compactMap { rawIcon -> FaviconURL? in
-            guard let rawFormat = rawIcon["src"] else { return nil }
-            guard let format = FaviconFormatType(rawValue: rawFormat) else { return nil }
-            guard let sizeTag = rawIcon["sizes"] else { return nil }
+            guard let rawFormat = rawIcon["src"] else {
+                return nil
+            }
+            guard let format = FaviconFormatType(rawValue: rawFormat) else {
+                return nil
+            }
+            guard let sizeTag = rawIcon["sizes"] else {
+                return nil
+            }
 
             let source = self.url.appendingPathComponent(rawFormat)
 
@@ -112,10 +118,14 @@ private extension WebApplicationManifestFaviconFinder {
             try $0.attr("rel") == self.preferredType
         }
 
-        guard let manifestFileAttr else { return nil }
+        guard let manifestFileAttr else {
+            return nil
+        }
         let rel = try manifestFileAttr.attr("rel")
         let href = try manifestFileAttr.attr("href")
-        guard let baseURL = href.baseUrl(from: htmlHead, from: self.url) else { return nil }
+        guard let baseURL = href.baseUrl(from: htmlHead, from: self.url) else {
+            return nil
+        }
 
         return ManifestFileReference(baseURL: baseURL, rel: rel, href: href)
     }

--- a/Sources/FaviconFinder/Types/Favicon.swift
+++ b/Sources/FaviconFinder/Types/Favicon.swift
@@ -21,7 +21,8 @@ public struct Favicon: Sendable {
 
     /// Upon instantiation, we will attempt to download the image at the provided location
     ///
-    /// - Parameter url: The `FaviconURL` that has the location to our image data
+    /// - parameter url: The `FaviconURL` that has the location to our image data
+    /// 
     public init(url: FaviconURL) async throws {
         self.url = url
 
@@ -33,4 +34,80 @@ public struct Favicon: Sendable {
 
         self.image = image
     }
+}
+
+// MARK: - [Favicon]
+
+/// Something important to note is that these functions require the `FaviconImage` to be downloaded (using the
+/// `download()` function first so comparison can take place.
+/// This is generally not advised unless you are in a situation where the size isn't indicated via HTML tags or WMAF
+/// tags.
+///
+///
+public extension Array where Element == Favicon {
+
+    /// Will pull the first `Favicon` from the array
+    ///
+    /// - Important: Why not jus use the `.first` computed variable that comes
+    /// with arrays? Because that variable returns `nil` if the array is empty. Throughout
+    /// this project, we throw an error if something has gone wrong rather than silently fail. To
+    /// ensure that consistency can be kept, this function is provided to developers and an
+    /// error will be thrown if the array is empty.
+    ///
+    /// - returns: The first `Favicon` in this array
+    ///
+    func first() throws -> Favicon {
+        guard let first = self.first else {
+            throw FaviconError.failedToFindFavicon
+        }
+
+        return first
+    }
+
+    /// Will pull the `Favicon` from the array that has the largest image size
+    ///
+    /// - returns: The `Favicon` that has the largest image
+    ///
+    func largest() throws -> Favicon {
+
+        // Find the Favicon with the largest image
+        let first = try self.first()
+        let largestImage = try self.reduce(first) { current, next in
+            guard let currentImage = current.image, let nextImage = next.image else {
+                throw FaviconError.faviconImageIsNotDownloaded
+            }
+
+            if currentImage.size > nextImage.size {
+                return current
+            } else {
+                return next
+            }
+        }
+
+        return largestImage
+    }
+
+    /// Will pull the `Favicon` from the array that has the smallest image size
+    ///
+    /// - returns: The `Favicon` that has the smallest image
+    ///
+    func smallest() throws -> Favicon {
+
+        // Find the Favicon with the smallest image
+        let first = try self.first()
+        let smallestImage = try self.reduce(first) { current, next in
+            guard let currentImage = current.image, let nextImage = next.image else {
+                throw FaviconError.faviconImageIsNotDownloaded
+            }
+
+            if currentImage.size < nextImage.size {
+                return current
+            } else {
+                return next
+            }
+        }
+
+        return smallestImage
+    }
+
 }

--- a/Sources/FaviconFinder/Types/FaviconFormatType.swift
+++ b/Sources/FaviconFinder/Types/FaviconFormatType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum FaviconFormatType: String, CaseIterable, Sendable {
+public enum FaviconFormatType: String, CaseIterable, Equatable, Sendable {
 
     // HTML Types
     case appleTouchIcon            = "apple-touch-icon"

--- a/Sources/FaviconFinder/Types/FaviconSourceType.swift
+++ b/Sources/FaviconFinder/Types/FaviconSourceType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum FaviconSourceType: Sendable {
+public enum FaviconSourceType: Equatable, Sendable {
     case html
     case ico
     case webApplicationManifestFile

--- a/Sources/FaviconFinder/Types/FaviconURL.swift
+++ b/Sources/FaviconFinder/Types/FaviconURL.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public struct FaviconURL: Sendable {
+
     /// The url of the .ico or HTML page, of where the favicon was found
     public let source: URL
 
@@ -19,4 +20,33 @@ public struct FaviconURL: Sendable {
 
     /// If the icon is from HTML/WAMF and we've been told it's size, we'll store that data here
     public let sizeTag: String?
+
+    /// Using the `sizeTag` this will return the indicated size of the image located at the URL.
+    /// If `sizeTag` is `nil`, then `nil` will be returned.
+    ///
+    /// - returns: The CGSize that is indicated in the `sizeTag`
+    ///
+    public var inferredSize: CGSize? {
+        // Split the size tag components into their individual numbers
+        guard let components = self.sizeTag?.split(separator: "x") else {
+            return nil
+        }
+
+        // Make sure we only got two components, or something has gone very wrong
+        guard components.count == 2 else {
+            return nil
+        }
+
+        // Grab the sizes as strings
+        let widthStr = components[0]
+        let heightStr = components[1]
+
+        // Let's convert those strings into doubles
+        guard let width = Double(widthStr), let height = Double(heightStr) else {
+            return nil
+        }
+
+        // Wrap it up in a pretty ~bow~ CGSize
+        return .init(width: width, height: height)
+    }
 }

--- a/Sources/FaviconFinder/Types/FaviconURL.swift
+++ b/Sources/FaviconFinder/Types/FaviconURL.swift
@@ -7,7 +7,16 @@
 
 import Foundation
 
-public struct FaviconURL: Sendable {
+public struct FaviconURL: Equatable, Sendable {
+
+    // MARK: - Types
+
+    public struct Size: Equatable, Sendable {
+        public let width: Double
+        public let height: Double
+    }
+
+    // MARK: - Properties
 
     /// The url of the .ico or HTML page, of where the favicon was found
     public let source: URL
@@ -30,9 +39,9 @@ public extension FaviconURL {
     /// Using the `sizeTag` this will return the indicated size of the image located at the URL.
     /// If `sizeTag` is `nil`, then `nil` will be returned.
     ///
-    /// - returns: The CGSize that is indicated in the `sizeTag`
+    /// - returns: The Size that is indicated in the `sizeTag`
     ///
-    var inferredSize: CGSize? {
+    var inferredSize: Size? {
         // Split the size tag components into their individual numbers
         guard let components = self.sizeTag?.split(separator: "x") else {
             return nil
@@ -52,7 +61,7 @@ public extension FaviconURL {
             return nil
         }
 
-        // Wrap it up in a pretty ~bow~ CGSize
+        // Wrap it up in a pretty ~bow~ Size
         return .init(width: width, height: height)
     }
 

--- a/Sources/FaviconFinder/Types/FaviconURL.swift
+++ b/Sources/FaviconFinder/Types/FaviconURL.swift
@@ -21,12 +21,18 @@ public struct FaviconURL: Sendable {
     /// If the icon is from HTML/WAMF and we've been told it's size, we'll store that data here
     public let sizeTag: String?
 
+}
+
+// MARK: - Public
+
+public extension FaviconURL {
+
     /// Using the `sizeTag` this will return the indicated size of the image located at the URL.
     /// If `sizeTag` is `nil`, then `nil` will be returned.
     ///
     /// - returns: The CGSize that is indicated in the `sizeTag`
     ///
-    public var inferredSize: CGSize? {
+    var inferredSize: CGSize? {
         // Split the size tag components into their individual numbers
         guard let components = self.sizeTag?.split(separator: "x") else {
             return nil
@@ -49,4 +55,124 @@ public struct FaviconURL: Sendable {
         // Wrap it up in a pretty ~bow~ CGSize
         return .init(width: width, height: height)
     }
+
+    /// Creates a `Favicon` instance with this `FaviconURL` information, which
+    /// will kickstart a download of the relevant image data, and then returns this data
+    /// and other relevant metadata in the `Favicon` struct.
+    ///
+    /// - returns: A `Favicon`, that contains the downloaded image data.
+    ///
+    func download() async throws -> Favicon {
+        guard let favicon = try? await Favicon(url: self) else {
+            throw FaviconError.failedToDownloadFavicon
+        }
+
+        return favicon
+    }
+
+}
+
+// MARK: - [FaviconURL]
+
+public extension Array where Element == FaviconURL {
+
+    /// Will iterate over each `FaviconURL` and analyse the `inferredSize`, and returns
+    /// the largest one.
+    ///
+    /// Notably, calling `largest()` on an array of `FaviconURL` instead of on an array of
+    /// `Favicon` means you can extrapolate the largest image without having to download all of them.
+    /// This comes with the drawbacks of
+    ///     1. Only being able to use this function appropriately if the source has set the sizeTags, either in the
+    ///       HTML or the WebApplicationManifestFile.
+    ///     2. Not being 100% certain, as the size in the sizeTags and the actual true size may be different due
+    ///       to the source being configured incorrectly.
+    ///
+    /// However there are plently of use cases where these drawbacks are worth it to get the largest image without
+    /// having to download them all, so here we are.
+    ///
+    /// - returns: A `FaviconURL` from the array of `FaviconURL`s that we deem to be the largest.
+    ///
+    func largest() async throws -> FaviconURL {
+        let largestFavicon = self
+            // Return true  if `a` is less than `b`
+            // Return false if `b` is less than `a`
+            .max { faviconA, faviconB in
+                guard let sizeA = faviconA.inferredSize else {
+                    return true
+                }
+                guard let sizeB = faviconB.inferredSize else {
+                    return false
+                }
+
+                let sizeAValue = sizeA.width * sizeA.height
+                let sizeBValue = sizeB.width * sizeB.height
+
+                return sizeAValue < sizeBValue
+            }
+
+        guard let largestFavicon else {
+            throw FaviconError.failedToFindFavicon
+        }
+        return largestFavicon
+    }
+
+    /// Will iterate over each `FaviconURL` and analyse the `inferredSize`, and returns
+    /// the smallest one.
+    ///
+    /// Notably, calling `smallest()` on an array of `FaviconURL` instead of on an array of
+    /// `Favicon` means you can extrapolate the smallest image without having to download all of them.
+    /// This comes with the drawbacks of
+    ///     1. Only being able to use this function appropriately if the source has set the sizeTags, either in the
+    ///       HTML or the WebApplicationManifestFile.
+    ///     2. Not being 100% certain, as the size in the sizeTags and the actual true size may be different due
+    ///       to the source being configured incorrectly.
+    ///
+    /// However there are plently of use cases where these drawbacks are worth it to get the smallest image without
+    /// having to download them all, so here we are.
+    ///
+    /// - returns: A `FaviconURL` from the array of `FaviconURL`s that we deem to be the smallest.
+    ///
+    func smallest() async throws -> FaviconURL {
+        let smallestFavicon = self
+            // Return true  if `a` is less than `b`
+            // Return false if `b` is less than `a`
+            .max { faviconA, faviconB in
+                guard let sizeA = faviconA.inferredSize else {
+                    return true
+                }
+                guard let sizeB = faviconB.inferredSize else {
+                    return false
+                }
+
+                let sizeAValue = sizeA.width * sizeA.height
+                let sizeBValue = sizeB.width * sizeB.height
+
+                return sizeAValue > sizeBValue
+            }
+
+        guard let smallestFavicon else {
+            throw FaviconError.failedToFindFavicon
+        }
+        return smallestFavicon
+
+    }
+
+    /// Will iterate over each FaviconURL in our array, and initiate
+    /// a `Favicon` instance after downloading the image data
+    /// at the source specified by the FaviconURL.
+    ///
+    /// - returns: An array of `Favicon`, each containing the downloaded image data.
+    ///
+    func download() async throws -> [Favicon] {
+        var favicons = [Favicon]()
+        for url in self {
+            guard let favicon = try? await Favicon(url: url) else {
+                continue
+            }
+            favicons.append(favicon)
+        }
+
+        return favicons
+    }
+
 }

--- a/Tests/FaviconFinderTests/FaviconURLTests.swift
+++ b/Tests/FaviconFinderTests/FaviconURLTests.swift
@@ -1,0 +1,15 @@
+//
+//  FaviconURLTests.swift
+//  FaviconFinder
+//
+//  Created by William Lumley on 24/9/2024.
+//
+
+@testable import FaviconFinder
+import Testing
+
+struct FaviconURLTests {
+
+    
+
+}

--- a/Tests/FaviconFinderTests/FaviconURLTests.swift
+++ b/Tests/FaviconFinderTests/FaviconURLTests.swift
@@ -5,11 +5,32 @@
 //  Created by William Lumley on 24/9/2024.
 //
 
+import CoreFoundation
 @testable import FaviconFinder
 import Testing
 
 struct FaviconURLTests {
 
-    
+    @Test("Test Inferred Size", arguments: [
+        ("180x180", 180, 180),
+        ("120x1080", 120, 1080),
+        ("100.50x20.02", 100.50, 20.02)
+    ])
+    func testInferredSize(
+        sizeTag: String,
+        rawWidth: Double,
+        rawHeight: Double
+    ) throws {
+        let testSubject = FaviconURL(
+            source: TestURL.google.url,
+            format: .appleTouchIcon,
+            sourceType: .html,
+            sizeTag: sizeTag
+        )
+
+        let inferredSize = try #require(testSubject.inferredSize)
+        #expect(inferredSize.width == CGFloat(rawWidth))
+        #expect(inferredSize.height == CGFloat(rawHeight))
+    }
 
 }

--- a/Tests/FaviconFinderTests/FaviconURLTests.swift
+++ b/Tests/FaviconFinderTests/FaviconURLTests.swift
@@ -11,7 +11,7 @@ import Testing
 
 struct FaviconURLTests {
 
-    @Test("Test Inferred Size", arguments: [
+    @Test("Inferred Size - Size Creation", arguments: [
         ("180x180", 180, 180),
         ("120x1080", 120, 1080),
         ("100.50x20.02", 100.50, 20.02)
@@ -29,8 +29,44 @@ struct FaviconURLTests {
         )
 
         let inferredSize = try #require(testSubject.inferredSize)
-        #expect(inferredSize.width == CGFloat(rawWidth))
-        #expect(inferredSize.height == CGFloat(rawHeight))
+        #expect(inferredSize.width == rawWidth)
+        #expect(inferredSize.height == rawHeight)
+    }
+
+    @Test("Test Size Sorting")
+    func testSizeSorting() async throws {
+        let testSubject = [
+            FaviconURL(
+                source: TestURL.google.url,
+                format: .appleTouchIcon,
+                sourceType: .html,
+                sizeTag: "100x100"
+            ),
+            FaviconURL(
+                source: TestURL.google.url,
+                format: .appleTouchIcon,
+                sourceType: .html,
+                sizeTag: "180x180"
+            ),
+            FaviconURL(
+                source: TestURL.google.url,
+                format: .appleTouchIcon,
+                sourceType: .html,
+                sizeTag: "181x181"
+            ),
+            FaviconURL(
+                source: TestURL.google.url,
+                format: .appleTouchIcon,
+                sourceType: .html,
+                sizeTag: "150x150"
+            )
+        ]
+
+        let largest = try await testSubject.largest()
+        #expect(largest == testSubject[2])
+
+        let smallest = try await testSubject.smallest()
+        #expect(smallest == testSubject[0])
     }
 
 }


### PR DESCRIPTION
This feature introduces the ability to sort FaviconURL entries by their inferred size, based on the metadata (`sizeTag`) provided in the HTML or web application manifest files. Importantly, this process occurs without downloading the favicon images, allowing for improved performance when selecting the largest or smallest favicon available.

**Sorting by Size Without Downloading**
•	New methods `largest()` and `smallest()` allow users to sort favicons by size based on the `sizeTag` metadata, without downloading the images first.
•	This enables more efficient selection of favicons, especially in cases where downloading all images would incur unnecessary overhead.

**Metadata-Based Sorting**
•	Sorting relies on the `sizeTag` attribute, which indicates the size of the favicon in the HTML or manifest.
•	If the `sizeTag` is not correctly provided or missing, the feature will fall back to default handling.

**Limitations**
•	Sorting accuracy depends on the presence and correctness of the sizeTag metadata. If metadata is incorrect or missing, the actual image size may differ from what’s indicated.
•	This feature is most useful when the source provides accurate metadata for favicon dimensions.

**Usage**
```swift
let faviconURLs = try await FaviconFinder(url: url)
    .fetchFaviconURLs()

// Find the largest favicon URL without downloading the image
let largestFavicon = try await faviconURLs.largest()

// Find the smallest favicon URL
let smallestFavicon = try await faviconURLs.smallest()

// Download the largest favicon after sorting
let favicon = try await largestFavicon.download()

// Or, more simply:

let largestFavicon = try await FaviconFinder(url: url)
    .fetchFaviconURLs()
    .largest()
    .download()
```