### PR TITLE
[BUGFIX] Removed SwiftLint plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,7 @@ let plugins: [Target.PluginUsage] = [
 let dependencies: [PackageDescription.Package.Dependency] = [
     // SwiftSoup is used to parse the HTML tree
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.7"),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3"),
-    .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.55.1")
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3")
 ]
 
 let targetDependencies: [Target.Dependency] = [
@@ -34,7 +33,7 @@ let targetDependencies: [Target.Dependency] = [
 ]
 
 let plugins: [Target.PluginUsage] = [
-    .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins")
+
 ]
 
 #endif

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -25,7 +25,7 @@ let plugins: [Target.PluginUsage] = [
 let dependencies: [PackageDescription.Package.Dependency] = [
     // SwiftSoup is used to parse the HTML tree
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.7"),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3"),
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3")
 ]
 
 let targetDependencies: [Target.Dependency] = [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -26,7 +26,6 @@ let dependencies: [PackageDescription.Package.Dependency] = [
     // SwiftSoup is used to parse the HTML tree
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.7"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3"),
-    .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.55.1")
 ]
 
 let targetDependencies: [Target.Dependency] = [
@@ -34,7 +33,7 @@ let targetDependencies: [Target.Dependency] = [
 ]
 
 let plugins: [Target.PluginUsage] = [
-    .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins")
+
 ]
 
 #endif


### PR DESCRIPTION
While it's good to have SwiftLint ensuring our codebase is clean, it's inadvertently running on developers who import `FaviconFinder` into their codebase - which is less than desirable.