### PR TITLE
[BUG] HeaderImage is now only fetched as an opt-in configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,23 @@ Limitations
 
 This functionality allows you to efficiently sort favicon URLs by size and download only the favicons you need, making it a powerful tool for handling favicons in an optimised manner.
 
+### Header & Hero Images
+
+There are times where you would like to fetch the header or hero image from a URL. You can let FaviconFinder know that you want it to do this with the `acceptHeaderImage` parameter in the configuration.
+With the default value set to `false`, this parameter is an opt-in one.
+
+You can use it as so:
+
+```swift
+let favicon = try await FaviconFinder(
+    url: url,
+    configuration: .init(acceptHeaderImage: true)
+)
+    .fetchFaviconURLs()
+    .download()
+    .largest()
+```
+
 ## Example Projects
 
 To run the example project, clone the repo, and open the example Xcode Project in either the `iOSFaviconFinderExample`, or `macOSFaviconFinderExample`, depending on your build target.
@@ -329,7 +346,7 @@ To install it, simply add the dependency to your Package.Swift file:
 ```swift
 ...
 dependencies: [
-    .package(url: "https://github.com/will-lumley/FaviconFinder.git", from: "5.1.2"),
+    .package(url: "https://github.com/will-lumley/FaviconFinder.git", from: "5.1.4"),
 ],
 targets: [
     .target( name: "YourTarget", dependencies: ["FaviconFinder"]),

--- a/Sources/FaviconFinder/FaviconFinder+Configuration.swift
+++ b/Sources/FaviconFinder/FaviconFinder+Configuration.swift
@@ -39,17 +39,20 @@ public extension FaviconFinder {
         /// Defaults to `false`.
         public let checkForMetaRefreshRedirect: Bool
 
-        /// HTTP headers to pass along with the HTTP request when fetching the favicon.
-        ///
-        /// This allows users to specify custom HTTP headers, such as user-agent or authorization tokens.
-        public let httpHeaders: [String: String?]?
-
         /// A prefetched HTML document that can be passed in if the user already has the HTML.
         ///
         /// If set, `FaviconFinder` will use this document instead of downloading the HTML
         /// from the specified URL.
         /// Useful when working with local HTML documents or when the HTML is already available in memory.
         public let prefetchedHTML: Document?
+
+        /// HTTP headers to pass along with the HTTP request when fetching the favicon.
+        ///
+        /// This allows users to specify custom HTTP headers, such as user-agent or authorization tokens.
+        public let httpHeaders: [String: String?]?
+
+        /// Determines whether we'll include a websites header image as a valid image to fetch
+        public let acceptHeaderImage: Bool
 
         // MARK: - Lifecycle
 
@@ -64,19 +67,22 @@ public extension FaviconFinder {
         ///   - prefetchedHTML: A pre-downloaded HTML document to use instead of fetching HTML from the
         ///   network. Defaults to `nil`.
         ///   - httpHeaders: HTTP headers to use when making requests. Defaults to `nil`.
+        ///   - acceptHeaderImage: Determines whether we'll include a websites header image as a valid image to fetch.
         ///
         public init(
             preferredSource: FaviconSourceType = .html,
             preferences: [FaviconSourceType: String] = [:],
             checkForMetaRefreshRedirect: Bool = false,
             prefetchedHTML: Document? = nil,
-            httpHeaders: [String: String?]? = nil
+            httpHeaders: [String: String?]? = nil,
+            acceptHeaderImage: Bool = false
         ) {
             self.preferredSource = preferredSource
             self.preferences = preferences
             self.checkForMetaRefreshRedirect = checkForMetaRefreshRedirect
             self.prefetchedHTML = prefetchedHTML
             self.httpHeaders = httpHeaders
+            self.acceptHeaderImage = acceptHeaderImage
         }
     }
 

--- a/Sources/FaviconFinder/Finders/HTMLFaviconFinder.swift
+++ b/Sources/FaviconFinder/Finders/HTMLFaviconFinder.swift
@@ -222,16 +222,26 @@ private extension HTMLFaviconFinder {
             var property = try meta.attr("property")
             let content = try meta.attr("content")
 
+            var format = FaviconFormatType(rawValue: property)
+
             // If this link's "property" is something other than an accepted image
             // format type, dismiss it
-            if FaviconFormatType(rawValue: property) == nil {
+            if format == nil {
 
                 // Okay so "property" gave us nothing, let's try name
                 property = try meta.attr("name")
-                if FaviconFormatType(rawValue: property) == nil {
+                format = FaviconFormatType(rawValue: property)
+                if format == nil {
                     // Still nothing, onto the next one
                     continue
                 }
+            }
+
+            // If this is a header image AND we don't accept header images,
+            // then we'll bail out
+            let isHeaderImage = format == .metaOpenGraphImage
+            if isHeaderImage && configuration.acceptHeaderImage == false {
+                continue
             }
 
             // Get the base URL from the href

--- a/macOSFaviconFinderExample/macOSFaviconFinderExample/ContentView.swift
+++ b/macOSFaviconFinderExample/macOSFaviconFinderExample/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct ContentView: View {
 
-    @State var urlStr = "https://apple.com/au"
+    @State var urlStr = "https://www.plinky.app"
     @ObservedObject var imageLoader = ImageLoader()
 
     var body: some View {
@@ -52,8 +52,9 @@ final class ImageLoader: ObservableObject {
                 preferredSource: .html,
                 preferences: [
                     .html: FaviconFormatType.appleTouchIcon.rawValue,
-                    .ico: "favicon.ico"
-                ]
+                    .ico: "favicon.ico",
+                ],
+                acceptHeaderImage: false
             )
         )
             .fetchFaviconURLs()


### PR DESCRIPTION
The HeaderImage of a website is now only downloaded if the `acceptsHeaderImage` parameter within the `FaviconFinder.Configuration` property set.
If you would like this functionality, please set the property to `true` within your configuration.